### PR TITLE
Expose reusable activity pipeline orchestrator helper

### DIFF
--- a/library/cli/commands/get_activity_data.py
+++ b/library/cli/commands/get_activity_data.py
@@ -1,8 +1,197 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+import argparse
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from time import perf_counter
+
+from library import io
+from library.common.log import logger
+from library.config import Config
+from library.pipelines.assay.chembl_assay import MAX_ACTIVITY_CHUNK_SIZE
 
 from . import _run
+
+MIN_ACTIVITY_TIMEOUT = 60.0
+
+
+@dataclass(slots=True)
+class ActivityCommandOptions:
+    """Options required to execute the activity pipeline programmatically."""
+
+    input_csv: Path | str
+    output_csv: Path | str | None = None
+    final_output: Path | str | None = None
+    limit: int | None = None
+    offset: int = 0
+    timeout: float | None = None
+    batch_size: int | None = None
+    workers: int | None = None
+    dry_run: bool = False
+    skip_existing: bool = False
+    force: bool = False
+    invocation: Sequence[str] | None = None
+
+
+def _normalise_optional_path(value: Path | str | None) -> Path | None:
+    """Return ``value`` as :class:`Path` when provided and meaningful."""
+
+    if value in (None, argparse.SUPPRESS):
+        return None
+    return value if isinstance(value, Path) else Path(value)
+
+
+def _normalise_path(value: Path | str) -> Path:
+    """Convert a mandatory path-like value to :class:`Path`."""
+
+    result = _normalise_optional_path(value)
+    if result is None:  # pragma: no cover - defensive programming
+        msg = "a concrete path value is required"
+        raise ValueError(msg)
+    return result
+
+
+def run_activity_pipeline(
+    cfg: Config,
+    options: ActivityCommandOptions,
+    *,
+    runner: Callable[[Config, argparse.Namespace], int] | None = None,
+    emit_completion_message: Callable[..., None] | None = None,
+) -> int:
+    """Execute the activity pipeline with orchestrator semantics.
+
+    The helper mirrors :func:`scripts.get_activity_data.run` but accepts a
+    structured ``options`` payload, enabling reuse from pipelines and tests.
+    ``runner`` and ``emit_completion_message`` are primarily intended for
+    dependency injection during testing; by default they fall back to the
+    implementation from :mod:`scripts.get_activity_data`.
+    """
+
+    if runner is None or emit_completion_message is None:  # pragma: no cover - lazy import
+        from scripts import get_activity_data as activity_cli
+
+        if runner is None:
+            runner = activity_cli.run_chembl
+        if emit_completion_message is None:
+            emit_completion_message = activity_cli._emit_completion_message
+
+    if runner is None or emit_completion_message is None:  # pragma: no cover - defensive
+        msg = "activity pipeline runner dependencies could not be resolved"
+        raise RuntimeError(msg)
+
+    start_time = perf_counter()
+
+    args = argparse.Namespace(
+        input_csv=_normalise_path(options.input_csv),
+        skip_existing=bool(options.skip_existing),
+        force=bool(options.force),
+        dry_run=bool(options.dry_run),
+    )
+    args.limit = options.limit
+    args.offset = options.offset
+    args.timeout = (
+        options.timeout
+        if options.timeout is not None
+        else getattr(getattr(cfg, "activity", object()), "timeout", None)
+    )
+    args.batch_size = (
+        options.batch_size
+        if options.batch_size is not None
+        else getattr(getattr(cfg, "activity", object()), "batch_size", None)
+    )
+    args.workers = (
+        options.workers
+        if options.workers is not None
+        else getattr(getattr(cfg, "activity", object()), "workers", None)
+    )
+    if options.invocation is not None:
+        args.invocation = tuple(str(part) for part in options.invocation)
+
+    final_output = _normalise_optional_path(options.final_output)
+    legacy_output = _normalise_optional_path(options.output_csv)
+    if final_output is None:
+        if legacy_output is not None:
+            output_path = legacy_output
+        else:
+            output_path = Path(io.default_output_path(args.input_csv, cfg.io))
+        args.final_out = output_path
+        args.output_csv = output_path
+    else:
+        output_path = final_output
+        args.final_out = output_path
+        args.output_csv = output_path
+
+    batch_size = getattr(cfg.activity, "batch_size", None)
+    if batch_size is not None and batch_size > MAX_ACTIVITY_CHUNK_SIZE:
+        logger.warning(
+            "activity_batch_size_clamped",
+            configured=batch_size,
+            limit=MAX_ACTIVITY_CHUNK_SIZE,
+        )
+        logger.warning(
+            f"Configured batch size {batch_size} exceeds the hard cap of {MAX_ACTIVITY_CHUNK_SIZE}; "
+            f"reducing to {MAX_ACTIVITY_CHUNK_SIZE}."
+        )
+        cfg.activity.batch_size = MAX_ACTIVITY_CHUNK_SIZE
+        args.batch_size = MAX_ACTIVITY_CHUNK_SIZE
+
+    timeout = getattr(cfg.activity, "timeout", None)
+    if timeout is not None and timeout < MIN_ACTIVITY_TIMEOUT:
+        logger.warning(
+            "activity_timeout_clamped",
+            configured=timeout,
+            minimum=MIN_ACTIVITY_TIMEOUT,
+        )
+        logger.warning(
+            f"Configured timeout {timeout} is below the minimum of {MIN_ACTIVITY_TIMEOUT}; "
+            f"increasing to {MIN_ACTIVITY_TIMEOUT}."
+        )
+        minimum_timeout = float(MIN_ACTIVITY_TIMEOUT)
+        cfg.activity.timeout = minimum_timeout
+        try:
+            args.timeout = float(minimum_timeout)
+        except (TypeError, ValueError):  # pragma: no cover - defensive
+            args.timeout = minimum_timeout
+
+    retry_attempts = getattr(cfg.retry, "max_attempts", None)
+    if retry_attempts is not None and retry_attempts <= 1:
+        logger.warning(
+            "activity_retry_disabled",
+            configured=retry_attempts,
+        )
+        logger.warning(
+            "Configured system.retry.max_attempts=%s disables urllib3 retry handling; "
+            "increase to at least 2 to tolerate transient network issues.",
+            retry_attempts,
+        )
+
+    api_retries = getattr(cfg.api, "retries", None)
+    if api_retries is not None and api_retries <= 0:
+        logger.warning(
+            "activity_api_retry_disabled",
+            configured=api_retries,
+        )
+        logger.warning(
+            "Configured chembl.api.retries=%s disables client-level request retries; "
+            "increase to 1 or more for resilience.",
+            api_retries,
+        )
+
+    if args.skip_existing and output_path.exists() and not args.force:
+        logger.info("pipeline_skip_existing", output=str(output_path))
+        logger.info(
+            f"Skipping execution because '{output_path}' already exists and --force was not provided."
+        )
+        emit_completion_message(
+            output_path=output_path,
+            processed_rows=None,
+            duration_s=perf_counter() - start_time,
+            mode="skip_existing",
+        )
+        return 0
+
+    return runner(cfg, args)
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -20,3 +209,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     """
 
     return _run("get_activity_data", argv)
+
+
+__all__ = [
+    "ActivityCommandOptions",
+    "MIN_ACTIVITY_TIMEOUT",
+    "run_activity_pipeline",
+    "main",
+]

--- a/library/pipelines/activity/__init__.py
+++ b/library/pipelines/activity/__init__.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from types import SimpleNamespace
-
+from library.cli.commands.get_activity_data import (
+    ActivityCommandOptions,
+    run_activity_pipeline,
+)
 from library.config import Config
 
 from library.pipelines.common import PipelineRunResult
@@ -69,8 +71,6 @@ def run_pipeline(config: Config, options: ActivityPipelineOptions) -> PipelineRu
             written=False,
         )
 
-    from scripts import get_activity_data as activity_cli  # Lazy import for cycles
-
     cfg = config.model_copy(deep=True)
     _update_activity_config(
         cfg,
@@ -81,21 +81,21 @@ def run_pipeline(config: Config, options: ActivityPipelineOptions) -> PipelineRu
         workers=options.workers,
     )
 
-    args = SimpleNamespace(
+    helper_options = ActivityCommandOptions(
         input_csv=Path(options.input_csv),
-        final_out=output_path,
         output_csv=output_path,
+        final_output=output_path,
         limit=options.limit,
         offset=options.offset,
-        timeout=options.timeout or cfg.activity.timeout,
-        batch_size=options.batch_size or cfg.activity.batch_size,
-        workers=options.workers or getattr(cfg.activity, "workers", 1),
+        timeout=options.timeout,
+        batch_size=options.batch_size,
+        workers=options.workers,
+        dry_run=options.dry_run,
         skip_existing=options.skip_existing,
         force=options.force,
-        dry_run=options.dry_run,
     )
 
-    exit_code = activity_cli.run(cfg, args)
+    exit_code = run_activity_pipeline(cfg, helper_options)
     reason = None if exit_code == 0 else "pipeline_failed"
     written = None if exit_code != 0 else True
     return PipelineRunResult(

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -75,6 +75,11 @@ from library.cli_utils import (
 from library.config import Config, _serialize_paths
 from library.common.log import logger
 from library.cli.logging import setup_cli_logging
+from library.cli.commands.get_activity_data import (
+    ActivityCommandOptions,
+    MIN_ACTIVITY_TIMEOUT,
+    run_activity_pipeline,
+)
 from library.pipelines.activity import run as activity_run
 from library.pipelines.common import add_pipeline_metadata
 from library.pipelines.common.metadata import get_pipeline_version
@@ -93,7 +98,6 @@ from library.common.fetch_retry import ChunkFailureTracker, compute_backoff_dela
 
 DEFAULT_INPUT_NAME = "activity.csv"
 DEFAULT_OUTPUT_STEM = "activities"
-MIN_ACTIVITY_TIMEOUT = 60.0
 PROGRAM_NAME = Path(__file__).with_suffix("").name
 
 def _args_invocation(args: argparse.Namespace) -> tuple[str, ...]:
@@ -1542,97 +1546,38 @@ def _generate_activity_postprocess_metrics(
     return metrics, report_path
 
 
+def _coerce_cli_path(value: object) -> Path | str | None:
+    """Normalise optional CLI path parameters for helper delegation."""
+
+    if value in (None, argparse.SUPPRESS):
+        return None
+    return value  # ``run_activity_pipeline`` handles conversion to :class:`Path`.
+
+
 def run(cfg: Config, args: argparse.Namespace) -> int:
     """Execute the activity pipeline handling ``--skip-existing`` semantics."""
 
-    start_time = perf_counter()
+    options = ActivityCommandOptions(
+        input_csv=getattr(args, "input_csv"),
+        output_csv=_coerce_cli_path(getattr(args, "output_csv", None)),
+        final_output=_coerce_cli_path(getattr(args, "final_out", None)),
+        limit=getattr(args, "limit", None),
+        offset=getattr(args, "offset", 0),
+        timeout=getattr(args, "timeout", None),
+        batch_size=getattr(args, "batch_size", None),
+        workers=getattr(args, "workers", None),
+        dry_run=getattr(args, "dry_run", False),
+        skip_existing=getattr(args, "skip_existing", False),
+        force=getattr(args, "force", False),
+        invocation=getattr(args, "invocation", None),
+    )
 
-    batch_size = getattr(cfg.activity, "batch_size", None)
-    if batch_size is not None and batch_size > MAX_ACTIVITY_CHUNK_SIZE:
-        logger.warning(
-            "activity_batch_size_clamped",
-            configured=batch_size,
-            limit=MAX_ACTIVITY_CHUNK_SIZE,
-        )
-        logger.warning(
-            f"Configured batch size {batch_size} exceeds the hard cap of {MAX_ACTIVITY_CHUNK_SIZE}; "
-            f"reducing to {MAX_ACTIVITY_CHUNK_SIZE}."
-        )
-        cfg.activity.batch_size = MAX_ACTIVITY_CHUNK_SIZE
-
-    timeout = getattr(cfg.activity, "timeout", None)
-    if timeout is not None and timeout < MIN_ACTIVITY_TIMEOUT:
-        logger.warning(
-            "activity_timeout_clamped",
-            configured=timeout,
-            minimum=MIN_ACTIVITY_TIMEOUT,
-        )
-        logger.warning(
-            f"Configured timeout {timeout} is below the minimum of {MIN_ACTIVITY_TIMEOUT}; "
-            f"increasing to {MIN_ACTIVITY_TIMEOUT}."
-        )
-        minimum_timeout = float(MIN_ACTIVITY_TIMEOUT)
-        cfg.activity.timeout = minimum_timeout
-        if hasattr(args, "timeout"):
-            try:
-                args.timeout = float(minimum_timeout)
-            except (TypeError, ValueError):  # pragma: no cover - defensive
-                args.timeout = minimum_timeout
-
-    retry_attempts = getattr(cfg.retry, "max_attempts", None)
-    if retry_attempts is not None and retry_attempts <= 1:
-        logger.warning(
-            "activity_retry_disabled",
-            configured=retry_attempts,
-        )
-        logger.warning(
-            "Configured system.retry.max_attempts=%s disables urllib3 retry handling; "
-            "increase to at least 2 to tolerate transient network issues.",
-            retry_attempts,
-        )
-
-    api_retries = getattr(cfg.api, "retries", None)
-    if api_retries is not None and api_retries <= 0:
-        logger.warning(
-            "activity_api_retry_disabled",
-            configured=api_retries,
-        )
-        logger.warning(
-            "Configured chembl.api.retries=%s disables client-level request retries; "
-            "increase to 1 or more for resilience.",
-            api_retries,
-        )
-
-    final_out_attr = getattr(args, "final_out", None)
-    if final_out_attr in (None, argparse.SUPPRESS):
-        legacy_output = getattr(args, "output_csv", None)
-        if legacy_output not in (None, argparse.SUPPRESS):
-            output_path = Path(legacy_output)
-            if not isinstance(legacy_output, Path):
-                args.final_out = output_path
-            setattr(args, "output_csv", output_path)
-        else:
-            output_path = Path(io.default_output_path(args.input_csv, cfg.io))
-            args.final_out = output_path
-            setattr(args, "output_csv", output_path)
-    else:
-        output_path = Path(final_out_attr)
-        if not isinstance(final_out_attr, Path):
-            args.final_out = output_path
-        setattr(args, "output_csv", output_path)
-    if args.skip_existing and output_path.exists() and not args.force:
-        logger.info("pipeline_skip_existing", output=str(output_path))
-        logger.info(
-            f"Skipping execution because '{output_path}' already exists and --force was not provided."
-        )
-        _emit_completion_message(
-            output_path=output_path,
-            processed_rows=None,
-            duration_s=perf_counter() - start_time,
-            mode="skip_existing",
-        )
-        return 0
-    return run_chembl(cfg, args)
+    return run_activity_pipeline(
+        cfg,
+        options,
+        runner=run_chembl,
+        emit_completion_message=_emit_completion_message,
+    )
 
 
 def _build_parser_impl() -> tuple[argparse.ArgumentParser, LoggerConfig]:

--- a/tests/integration/test_get_activity_data_pipeline.py
+++ b/tests/integration/test_get_activity_data_pipeline.py
@@ -20,6 +20,8 @@ from dataclasses import dataclass
 
 from config.paths import DICTIONARY_DIR
 from scripts import get_activity_data
+from library.cli.commands import get_activity_data as command_activity
+from library.config import Config
 from library.resources.dictionaries import get_resource
 
 
@@ -188,9 +190,61 @@ def _make_args(input_csv: Path, output_csv: Path) -> argparse.Namespace:
     )
 
 
+def _activity_options_from_args(args: argparse.Namespace) -> command_activity.ActivityCommandOptions:
+    """Construct :class:`ActivityCommandOptions` mirroring CLI semantics."""
+
+    return command_activity.ActivityCommandOptions(
+        input_csv=args.input_csv,
+        output_csv=args.output_csv,
+        final_output=args.output_csv,
+        limit=getattr(args, "limit", None),
+        offset=getattr(args, "offset", 0),
+        timeout=getattr(args, "timeout", None),
+        batch_size=getattr(args, "batch_size", None),
+        workers=getattr(args, "workers", None),
+        dry_run=getattr(args, "dry_run", False),
+        skip_existing=getattr(args, "skip_existing", False),
+        force=getattr(args, "force", False),
+        invocation=getattr(args, "invocation", None),
+    )
+
+
+def _patch_activity_loggers(monkeypatch: pytest.MonkeyPatch, logger_stub: _RecordingLogger) -> None:
+    """Ensure both CLI entry points emit logs to the stub."""
+
+    monkeypatch.setattr(get_activity_data, "logger", logger_stub)
+    monkeypatch.setattr(command_activity, "logger", logger_stub)
+
+
+def _invoke_activity_runner(
+    cfg,
+    args: argparse.Namespace,
+    variant: str,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    runner: Callable[[Config, argparse.Namespace], int],
+) -> int:
+    """Execute the orchestrator via the requested variant."""
+
+    if variant == "cli":
+        monkeypatch.setattr(get_activity_data, "run_chembl", runner)
+        return get_activity_data.run(cfg, args)
+
+    helper_options = _activity_options_from_args(args)
+    return command_activity.run_activity_pipeline(
+        cfg,
+        helper_options,
+        runner=runner,
+        emit_completion_message=get_activity_data._emit_completion_message,
+    )
+
+
 @pytest.mark.integration
 @pytest.mark.usefixtures("deterministic_env")
-def test_activity_pipeline__timeout_clamped_when_below_minimum(cfg, tmp_path, monkeypatch):
+@pytest.mark.parametrize("runner_variant", ["cli", "api"])
+def test_activity_pipeline__timeout_clamped_when_below_minimum(
+    cfg, tmp_path, monkeypatch, runner_variant
+) -> None:
     _configure_cfg(cfg)
     cfg.activity.timeout = get_activity_data.MIN_ACTIVITY_TIMEOUT - 5
 
@@ -199,7 +253,7 @@ def test_activity_pipeline__timeout_clamped_when_below_minimum(cfg, tmp_path, mo
     output_csv = tmp_path / "activities.csv"
 
     logger_stub = _RecordingLogger()
-    monkeypatch.setattr(get_activity_data, "logger", logger_stub)
+    _patch_activity_loggers(monkeypatch, logger_stub)
 
     captured_timeout: dict[str, float] = {}
 
@@ -207,11 +261,15 @@ def test_activity_pipeline__timeout_clamped_when_below_minimum(cfg, tmp_path, mo
         captured_timeout["timeout"] = float(passed_cfg.activity.timeout)
         return 0
 
-    monkeypatch.setattr(get_activity_data, "run_chembl", _run_chembl_stub)
-
     args = _make_args(input_csv, output_csv)
 
-    exit_code = get_activity_data.run(cfg, args)
+    exit_code = _invoke_activity_runner(
+        cfg,
+        args,
+        runner_variant,
+        monkeypatch,
+        runner=_run_chembl_stub,
+    )
 
     warning_events = [event for level, event, _ in logger_stub.events if level == "warning"]
     assert "activity_timeout_clamped" in warning_events
@@ -222,7 +280,10 @@ def test_activity_pipeline__timeout_clamped_when_below_minimum(cfg, tmp_path, mo
 
 @pytest.mark.integration
 @pytest.mark.usefixtures("deterministic_env")
-def test_activity_pipeline__warns_when_retry_disabled(cfg, tmp_path, monkeypatch):
+@pytest.mark.parametrize("runner_variant", ["cli", "api"])
+def test_activity_pipeline__warns_when_retry_disabled(
+    cfg, tmp_path, monkeypatch, runner_variant
+) -> None:
     _configure_cfg(cfg)
     cfg.retry.max_attempts = 1
 
@@ -231,17 +292,21 @@ def test_activity_pipeline__warns_when_retry_disabled(cfg, tmp_path, monkeypatch
     output_csv = tmp_path / "activities.csv"
 
     logger_stub = _RecordingLogger()
-    monkeypatch.setattr(get_activity_data, "logger", logger_stub)
+    _patch_activity_loggers(monkeypatch, logger_stub)
 
     def _run_stub(passed_cfg, _args):
         assert passed_cfg.retry.max_attempts == 1
         return 0
 
-    monkeypatch.setattr(get_activity_data, "run_chembl", _run_stub)
-
     args = _make_args(input_csv, output_csv)
 
-    exit_code = get_activity_data.run(cfg, args)
+    exit_code = _invoke_activity_runner(
+        cfg,
+        args,
+        runner_variant,
+        monkeypatch,
+        runner=_run_stub,
+    )
 
     warning_events = [event for level, event, _ in logger_stub.events if level == "warning"]
     assert "activity_retry_disabled" in warning_events
@@ -250,7 +315,10 @@ def test_activity_pipeline__warns_when_retry_disabled(cfg, tmp_path, monkeypatch
 
 @pytest.mark.integration
 @pytest.mark.usefixtures("deterministic_env")
-def test_activity_pipeline__warns_when_api_retries_disabled(cfg, tmp_path, monkeypatch):
+@pytest.mark.parametrize("runner_variant", ["cli", "api"])
+def test_activity_pipeline__warns_when_api_retries_disabled(
+    cfg, tmp_path, monkeypatch, runner_variant
+) -> None:
     _configure_cfg(cfg)
     cfg.api.retries = 0
 
@@ -259,17 +327,21 @@ def test_activity_pipeline__warns_when_api_retries_disabled(cfg, tmp_path, monke
     output_csv = tmp_path / "activities.csv"
 
     logger_stub = _RecordingLogger()
-    monkeypatch.setattr(get_activity_data, "logger", logger_stub)
+    _patch_activity_loggers(monkeypatch, logger_stub)
 
     def _run_stub(passed_cfg, _args):
         assert passed_cfg.api.retries == 0
         return 0
 
-    monkeypatch.setattr(get_activity_data, "run_chembl", _run_stub)
-
     args = _make_args(input_csv, output_csv)
 
-    exit_code = get_activity_data.run(cfg, args)
+    exit_code = _invoke_activity_runner(
+        cfg,
+        args,
+        runner_variant,
+        monkeypatch,
+        runner=_run_stub,
+    )
 
     warning_events = [event for level, event, _ in logger_stub.events if level == "warning"]
     assert "activity_api_retry_disabled" in warning_events
@@ -548,7 +620,13 @@ def test_activity_pipeline__missing_column_input(activity_resource_dir: Path, cf
 
 @pytest.mark.integration
 @pytest.mark.usefixtures("deterministic_env")
-def test_activity_pipeline__batch_size_clamped(cfg, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+@pytest.mark.parametrize("runner_variant", ["cli", "api"])
+def test_activity_pipeline__batch_size_clamped(
+    cfg,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    runner_variant,
+) -> None:
     _configure_cfg(cfg)
     cfg.activity.batch_size = get_activity_data.MAX_ACTIVITY_CHUNK_SIZE + 5
 
@@ -557,7 +635,7 @@ def test_activity_pipeline__batch_size_clamped(cfg, tmp_path: Path, monkeypatch:
     output_csv = tmp_path / "activities.csv"
 
     logger_stub = _RecordingLogger()
-    monkeypatch.setattr(get_activity_data, "logger", logger_stub)
+    _patch_activity_loggers(monkeypatch, logger_stub)
 
     captured_batch_sizes: list[int | None] = []
 
@@ -565,11 +643,15 @@ def test_activity_pipeline__batch_size_clamped(cfg, tmp_path: Path, monkeypatch:
         captured_batch_sizes.append(getattr(config.activity, "batch_size", None))
         return 0
 
-    monkeypatch.setattr(get_activity_data, "run_chembl", _fake_run_chembl)
-
     args = _make_args(input_csv, output_csv)
 
-    exit_code = get_activity_data.run(cfg, args)
+    exit_code = _invoke_activity_runner(
+        cfg,
+        args,
+        runner_variant,
+        monkeypatch,
+        runner=_fake_run_chembl,
+    )
 
     assert exit_code == 0
     assert captured_batch_sizes == [get_activity_data.MAX_ACTIVITY_CHUNK_SIZE]


### PR DESCRIPTION
## Summary
- move the activity pipeline orchestration logic into a reusable helper under `library.cli.commands.get_activity_data`
- update the activity pipeline wrapper and CLI script to construct dataclass options and delegate to the shared helper
- extend integration tests to exercise the new helper alongside the CLI entry point to ensure behaviour parity

## Testing
- pytest tests/integration/test_get_activity_data_pipeline.py -k "timeout_clamped or warns_when_retry_disabled or warns_when_api_retries_disabled or batch_size_clamped" -q

------
https://chatgpt.com/codex/tasks/task_e_68e57463871883249d1592343206802c