### PR TITLE
Fix activity postprocess boolean defaults

### DIFF
--- a/library/postprocessing/activity_extended.py
+++ b/library/postprocessing/activity_extended.py
@@ -85,6 +85,14 @@ _REQUIRED_COLUMN_DTYPES: Mapping[str, str] = {
     "nstereo": "Int64",
 }
 
+_OPTIONAL_EMPTY_BACKFILL_COLUMNS: frozenset[str] = frozenset(
+    {
+        "multmol_assay",
+        "original_activity_approx",
+        "original_activity_exact",
+    }
+)
+
 _NA_MARKERS: tuple[str, ...] = ("[#N/A]",)
 
 _ACTIVITY_INPUT_SCHEMA: Mapping[str, str] = {
@@ -1271,25 +1279,45 @@ def _augment_activity_frame(frame: pd.DataFrame) -> tuple[pd.DataFrame, set[str]
     if not log_value_filled and not log_value_column_present and not log_value_series.notna().any():
         filled.discard("log_value")
 
-    bool_defaults = {
-        "multmol_assay",
+    bool_defaults = (
         "approx_cited_activity",
         "shuffled_cit",
         "exact_cited_activity",
         "higly_correlated_cit",
         "review_doc",
         "rounded_data_citation",
-    }
+    )
     for column in bool_defaults:
         if column not in df.columns:
             df[column] = pd.Series(False, index=df.index, dtype="boolean")
             filled.add(column)
+            continue
 
-    float_defaults = {"original_activity_approx", "original_activity_exact"}
-    for column in float_defaults:
-        if column not in df.columns:
-            df[column] = pd.Series(pd.NA, index=df.index, dtype="Float64")
+        series = _safe_to_bool(df[column], column)
+        try:
+            series = series.astype("boolean")
+        except (TypeError, ValueError):
+            mask = series.isna()
+            if mask.any():
+                series = series.copy()
+                series.loc[mask] = False
+                filled.add(column)
+            df[column] = series
+            continue
+
+        mask = series.isna()
+        if mask.any():
+            series = series.copy()
+            series.loc[mask] = False
             filled.add(column)
+        df[column] = series
+
+    string_defaults = {"original_activity_approx", "original_activity_exact"}
+    for column in string_defaults:
+        if column not in df.columns:
+            df[column] = pd.Series(pd.NA, index=df.index, dtype="string")
+        else:
+            df[column] = df[column].astype("string")
 
     if "salt_chembl_id" not in df.columns:
         df["salt_chembl_id"] = pd.Series(pd.NA, index=df.index, dtype="string")
@@ -1341,7 +1369,11 @@ def _transform_activity_frame(
         unresolved_columns = sorted(
             column
             for column in filled
-            if column not in df.columns or df[column].isna().all()
+            if column not in df.columns
+            or (
+                df[column].isna().all()
+                and column not in _OPTIONAL_EMPTY_BACKFILL_COLUMNS
+            )
         )
         resolved_columns = sorted(set(filled) - set(unresolved_columns))
 

--- a/tests/integration/test_activity_extended_integration.py
+++ b/tests/integration/test_activity_extended_integration.py
@@ -172,6 +172,15 @@ def test_process_activity_extended__fills_missing_optional_columns(tmp_path, cap
     for column_name in ("activity_chembl_id", "compound_key", "log_value"):
         assert column_name in message
 
+    unresolved_messages = [
+        record.message
+        for record in caplog.records
+        if "activity_extended_missing_columns_unresolved" in record.message
+    ]
+    assert len(unresolved_messages) <= 1
+    for message in unresolved_messages:
+        assert "nstereo" in message
+
 
 @pytest.mark.integration
 def test_process_activity_extended__warns_on_unresolved_parent(tmp_path, caplog):

--- a/tests/postprocessing/test_activity_extended.py
+++ b/tests/postprocessing/test_activity_extended.py
@@ -60,8 +60,8 @@ EXPECTED_DTYPE_MAP: dict[str, str] = {
     "nam": "boolean",
     "pam": "boolean",
     "high_citation_rate": "boolean",
-    "original_activity_approx": "object",
-    "original_activity_exact": "object",
+    "original_activity_approx": "string",
+    "original_activity_exact": "string",
     "is_citation": "boolean",
     "IUPHAR_class": "string",
     "IUPHAR_subclass": "string",
@@ -198,6 +198,34 @@ def test_augment_activity_frame__fills_blank_salt_and_log_value() -> None:
     )
     assert {"salt_chembl_id", "log_value"} <= filled
 
+
+def test_augment_activity_frame__fills_missing_boolean_defaults() -> None:
+    frame = pd.DataFrame(
+        {
+            "approx_cited_activity": pd.Series([pd.NA, True], dtype="boolean"),
+            "shuffled_cit": pd.Series([pd.NA, pd.NA], dtype="boolean"),
+            "exact_cited_activity": pd.Series([pd.NA, False], dtype="boolean"),
+            "higly_correlated_cit": pd.Series([pd.NA, pd.NA], dtype="boolean"),
+            "review_doc": pd.Series([pd.NA, pd.NA], dtype="boolean"),
+            "rounded_data_citation": pd.Series([pd.NA, pd.NA], dtype="boolean"),
+        }
+    )
+
+    augmented, filled = _augment_activity_frame(frame)
+
+    expectations = {
+        "approx_cited_activity": [False, True],
+        "shuffled_cit": [False, False],
+        "exact_cited_activity": [False, False],
+        "higly_correlated_cit": [False, False],
+        "review_doc": [False, False],
+        "rounded_data_citation": [False, False],
+    }
+
+    for column, values in expectations.items():
+        assert str(augmented[column].dtype) == "boolean"
+        assert augmented[column].tolist() == values
+        assert column in filled
 
 def test_rename_columns__propagates_backfilled_pA_value() -> None:
     frame = pd.DataFrame(
@@ -505,7 +533,7 @@ def test_transform_activity_frame__fills_missing_columns(activity_resources: Pat
     assert row["molecule_chembl_id.1"] == "MOL-1"
     assert row.standard_inchi_skeleton == "InChI=1"
     assert bool(row.multmol_assay) is False
-    assert pd.isna(row.rounded_data_citation)
+    assert bool(row.rounded_data_citation) is False
     assert pd.isna(row.original_activity_approx)
     assert pd.isna(row.original_activity_exact)
     assert float(row.pA_value) == pytest.approx(5.0)


### PR DESCRIPTION
## Summary
- ensure activity citation flag columns are coerced to boolean defaults while allowing multmol_assay to resolve later in the pipeline
- normalise original activity columns to pandas string dtype and ignore empty backfills when computing unresolved columns
- extend activity extended tests to cover boolean backfilling behaviour and narrow the unresolved warning expectations

## Testing
- pytest tests/postprocessing/test_activity_extended.py -q
- pytest tests/integration/test_activity_extended_integration.py::test_process_activity_extended__fills_missing_optional_columns -q


------
https://chatgpt.com/codex/tasks/task_e_68e5e39c97e083248f39507120c5fb8d