### PR TITLE
docs: correct CLI defaults in usage guides

### DIFF
--- a/docs/en/USAGE.md
+++ b/docs/en/USAGE.md
@@ -87,7 +87,7 @@ Common options:
 | `--mode` | required | Selects the processing flow. |
 | `--column` | Mode specific (`PMID` for `pubmed`, `document_chembl_id` otherwise) | Input column holding identifiers. |
 | `--limit`, `--offset` | `None`, `0` | Control record ranges. |
-| `--timeout` | `30.0` for `chembl`/`all`, `10.0` for `pubmed` | Applied to HTTP calls. |
+| `--timeout` | `90.0` for `chembl`/`all`, `10.0` for `pubmed` | Applied to HTTP calls. |
 | `--openalex-rps`, `--crossref-rps` | `None` | Optional overrides for partner APIs when running `pubmed` or `all`. |
 
 PubMed specific flags (`--mode pubmed` or `all`):
@@ -99,7 +99,7 @@ PubMed specific flags (`--mode pubmed` or `all`):
 
 ChEMBL specific flags (`--mode chembl` or `all`):
 
-- `--chunk-size` — identifiers per API call (default `5`).
+- `--chunk-size` — identifiers per API call (default `20`).
 - `--chembl-chunk-size`, `--chembl-timeout` — overrides applied only when running
   `--mode all`.
 
@@ -159,8 +159,8 @@ Shared options across all modes:
 | Option | Default | Description |
 |--------|---------|-------------|
 | `--column` | `target_chembl_id` | ChEMBL target identifier column. |
-| `--chunk-size` | `5` | Identifiers per request. |
-| `--timeout` | `30.0` | Request timeout. |
+| `--chunk-size` | `3` | Identifiers per request. |
+| `--timeout` | `90.0` | Request timeout. |
 
 #### `iuphar`
 

--- a/docs/ru/USAGE.md
+++ b/docs/ru/USAGE.md
@@ -86,7 +86,7 @@ python scripts/get_data.py \
 | `--mode` | обязательно | Выбор сценария. |
 | `--column` | Зависит от режима (`PMID` для `pubmed`, `document_chembl_id` в остальных случаях) | Колонка с идентификаторами. |
 | `--limit`, `--offset` | `None`, `0` | Управление диапазоном. |
-| `--timeout` | `30.0` (`chembl`/`all`), `10.0` (`pubmed`) | Таймаут HTTP-запросов. |
+| `--timeout` | `90.0` (`chembl`/`all`), `10.0` (`pubmed`) | Таймаут HTTP-запросов. |
 | `--openalex-rps`, `--crossref-rps` | `None` | Переопределение ограничений для партнёрских API при режимах `pubmed` или `all`. |
 
 Флаги PubMed (`--mode pubmed` или `all`):
@@ -98,7 +98,7 @@ python scripts/get_data.py \
 
 Флаги ChEMBL (`--mode chembl` или `all`):
 
-- `--chunk-size` — количество идентификаторов на запрос (по умолчанию `5`).
+- `--chunk-size` — количество идентификаторов на запрос (по умолчанию `20`).
 - `--chembl-chunk-size`, `--chembl-timeout` — переопределения для режима `all`.
 
 Обработка резервных DOI:
@@ -156,8 +156,8 @@ python scripts/get_document_data.py --mode pubmed \
 | Опция | Значение | Описание |
 |-------|----------|----------|
 | `--column` | `target_chembl_id` | Колонка с идентификаторами ChEMBL. |
-| `--chunk-size` | `5` | Идентификаторов на запрос. |
-| `--timeout` | `30.0` | Таймаут запросов. |
+| `--chunk-size` | `3` | Идентификаторов на запрос. |
+| `--timeout` | `90.0` | Таймаут запросов. |
 
 #### `iuphar`
 


### PR DESCRIPTION
## Summary
- update the EN/RU usage references to reflect the current document and target pipeline defaults for timeouts and chunk sizes

## Testing
- not run (docs-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e5e6ecbc308324acb5dc8c840e5686