### PR TITLE
Synchronise activity CLI logger with command module

### DIFF
--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -75,6 +75,7 @@ from library.cli_utils import (
 from library.config import Config, _serialize_paths
 from library.common.log import logger
 from library.cli.logging import setup_cli_logging
+from library.cli.commands import get_activity_data as _activity_cli_commands
 from library.cli.commands.get_activity_data import (
     ActivityCommandOptions,
     MIN_ACTIVITY_TIMEOUT,
@@ -116,6 +117,16 @@ __all__ = (
     "write_meta_yaml",
     "configure_logger",
 )
+
+
+def _ensure_command_logger_sync() -> None:
+    """Keep the shared command module logger aligned with this script logger."""
+
+    if getattr(_activity_cli_commands, "logger", None) is not logger:
+        _activity_cli_commands.logger = logger
+
+
+_ensure_command_logger_sync()
 
 
 _CACHE_MISS = object()
@@ -1556,6 +1567,8 @@ def _coerce_cli_path(value: object) -> Path | str | None:
 
 def run(cfg: Config, args: argparse.Namespace) -> int:
     """Execute the activity pipeline handling ``--skip-existing`` semantics."""
+
+    _ensure_command_logger_sync()
 
     options = ActivityCommandOptions(
         input_csv=getattr(args, "input_csv"),


### PR DESCRIPTION
## Summary
- ensure the activity CLI script shares its logger instance with the command-module helper so skip-existing events are captured
- synchronise the logger reference both at import time and immediately before invoking the shared pipeline runner

## Testing
- pytest tests/e2e/test_get_cli_pipelines.py::test_get_activity_run_skip_existing -q

------
https://chatgpt.com/codex/tasks/task_e_68e5f6d50df883249c4fca9ac29b9981