### PR TITLE
Allow post-processing of UniProt aggregated export

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -327,7 +327,6 @@ def _export_stem(name: str) -> str:
 _UNSUPPORTED_EXPORT_SUFFIXES: tuple[str, ...] = (
     RAW_SUFFIX.lower(),
     "_chembl",
-    "_uniprot",
     "_iuphar",
 )
 

--- a/tests/unit/test_get_target_data.py
+++ b/tests/unit/test_get_target_data.py
@@ -81,6 +81,7 @@ def test_keyboard_aliases__cases(command: str) -> None:
         ("targets_20251005_normalized.csv", True),
         ("output.targets_20251005.csv.tmp", True),
         (".output.targets_20251005.csv_normalized.tmp", True),
+        ("output.targets_uniprot.csv", True),
         ("targets.csv", True),
         ("out.csv", False),
         ("out_chembl.csv", False),


### PR DESCRIPTION
## Summary
- allow the aggregated UniProt targets export to pass the supported-name filter
- cover the new export name in the target export support test matrix

## Testing
- pytest tests/unit/test_get_target_data.py -k is_supported_target_export -q

------
https://chatgpt.com/codex/tasks/task_e_68e5f7c2ae648324b5a676b1b396c4e0