### PR TITLE
Handle PubChem SMILES lookups requiring POST

### DIFF
--- a/library/clients/pubchem.py
+++ b/library/clients/pubchem.py
@@ -10,7 +10,7 @@ from email.utils import parsedate_to_datetime
 from numbers import Real
 from threading import Lock
 from time import monotonic
-from typing import Any, cast
+from typing import Any, Mapping, cast
 from urllib.parse import quote
 
 import requests
@@ -181,12 +181,20 @@ def _cids_from_identifier_list(data: dict[str, Any]) -> list[str]:
 def get_cid_from_smiles(smiles: str, cfg: PubChemCfg) -> str | None:
     """Retrieve PubChem CID(s) for a SMILES string."""
 
-    safe_smiles = url_encode(smiles)
     base = cfg.base.rstrip("/")
-    url = f"{base}/compound/smiles/{safe_smiles}/cids/JSON"
-    response = make_request(url, cfg)
-    if not response:
-        return None
+    contains_path_separators = "/" in smiles or "\\" in smiles
+
+    if not contains_path_separators:
+        safe_smiles = url_encode(smiles)
+        url = f"{base}/compound/smiles/{safe_smiles}/cids/JSON"
+        response = make_request(url, cfg)
+        if not response:
+            return None
+    else:
+        url = f"{base}/compound/smiles/cids/JSON"
+        response = make_request(url, cfg, method="POST", payload={"smiles": smiles})
+        if not response:
+            return None
     cids = _cids_from_identifier_list(response)
     unique_cids = sorted(set(cids))
     return "|".join(unique_cids) if unique_cids else None
@@ -220,14 +228,35 @@ def get_cid_from_inchikey(inchikey: str, cfg: PubChemCfg) -> str | None:
     return "|".join(unique_cids) if unique_cids else None
 
 
-def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
-    """Make an HTTP GET request and return parsed JSON."""
+def _build_cache_key(method: str, url: str, data: Mapping[str, Any] | None = None) -> str:
+    """Return a stable cache key for ``method``/``url``/``data`` combinations."""
+
+    method_upper = method.upper()
+    if not data:
+        return f"{method_upper} {url}"
+    try:
+        serialised = json.dumps(data, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    except TypeError:
+        serialised = repr(sorted(data.items()))
+    return f"{method_upper} {url}?{serialised}"
+
+
+def make_request(
+    url: str,
+    cfg: PubChemCfg,
+    *,
+    method: str = "GET",
+    payload: Mapping[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    """Make an HTTP request and return parsed JSON."""
 
     global _CACHE
+    method_upper = method.upper()
+    cache_key = _build_cache_key(method_upper, url, payload)
     timeout_retry_in: float | None = None
     with _CACHE_LOCK:
         cache = _ensure_cache(cfg.cache_ttl, cfg.cache_maxsize)
-        cached = cache.get(url) if cache is not None else None
+        cached = cache.get(cache_key) if cache is not None else None
         if (
             cached is not None
             and not cached.is_hit
@@ -241,32 +270,33 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
                 if elapsed < float(retry_after):
                     timeout_retry_in = float(retry_after) - elapsed
                 else:
-                    cache.pop(url, None)
+                    cache.pop(cache_key, None)
                     cached = None
     if cached is not None:
         if cached.is_hit:
-            logger.debug("cache_hit", url=url, rps=cfg.rps, status="hit")
+            logger.debug("cache_hit", url=url, rps=cfg.rps, status="hit", method=method_upper)
             return cast(dict[str, Any], cached.payload)
-            miss_details: dict[str, Any] = {}
-            for key, value in (cached.details or {}).items():
-                if key == "timeout_stored_at":
-                    continue
-                if key == "status":
-                    miss_details["http_status"] = value
-                else:
-                    miss_details[key] = value
-            if timeout_retry_in is not None:
-                miss_details["timeout_retry_in"] = timeout_retry_in
-            logger.debug(
-                "cache_hit",
-                url=url,
+        miss_details: dict[str, Any] = {}
+        for key, value in (cached.details or {}).items():
+            if key == "timeout_stored_at":
+                continue
+            if key == "status":
+                miss_details["http_status"] = value
+            else:
+                miss_details[key] = value
+        if timeout_retry_in is not None:
+            miss_details["timeout_retry_in"] = timeout_retry_in
+        logger.debug(
+            "cache_hit",
+            url=url,
             rps=cfg.rps,
             status="miss",
+            method=method_upper,
             outcome=cached.outcome,
             **miss_details,
         )
         return None
-    logger.debug("cache_miss", url=url, rps=cfg.rps, status="miss")
+    logger.debug("cache_miss", url=url, rps=cfg.rps, status="miss", method=method_upper)
 
     api_cfg = ApiCfg(user_agent=cfg.user_agent)
 
@@ -293,17 +323,25 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
             logger.warning(
                 "request_timeout",
                 url=url,
+                method=method_upper,
                 attempt=attempt,
                 total_attempts=total_attempts,
                 rps=cfg.rps,
                 **(last_failure_details or {}),
             )
-            _store_cache_miss(url, cfg, "timeout", last_failure_details)
+            _store_cache_miss(
+                cache_key,
+                cfg,
+                "timeout",
+                last_failure_details,
+                url=url,
+            )
             logger.debug(
                 "request_fail",
                 url=url,
                 status=None,
                 total_attempts=total_attempts,
+                method=method_upper,
                 rps=cfg.rps,
                 **details_excluding("status"),
             )
@@ -319,24 +357,35 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
         get_limiter("pubchem", cfg.rps, cfg.burst).acquire()
         try:
             session = get_session(api_cfg)
-            with session.get(
-                url, timeout=(cfg.timeout_connect, cfg.timeout_read)
-            ) as response:
+            request_kwargs: dict[str, Any] = {
+                "timeout": (cfg.timeout_connect, cfg.timeout_read),
+            }
+            if method_upper != "GET" and payload is not None:
+                request_kwargs["data"] = payload
+            with session.request(method_upper, url, **request_kwargs) as response:
                 status = response.status_code
                 if status == 404:
                     last_failure_details = {"reason": "not_found", "status": status}
                     logger.info(
                         "request_not_found",
                         url=url,
+                        method=method_upper,
                         rps=cfg.rps,
                         status=status,
                         **details_excluding("status"),
                     )
-                    _store_cache_miss(url, cfg, "not_found", last_failure_details)
+                    _store_cache_miss(
+                        cache_key,
+                        cfg,
+                        "not_found",
+                        last_failure_details,
+                        url=url,
+                    )
                     logger.debug(
                         "request_fail",
                         url=url,
                         total_attempts=total_attempts,
+                        method=method_upper,
                         rps=cfg.rps,
                         status=status,
                         **details_excluding("status"),
@@ -356,6 +405,7 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
                     )
                     warning_context: dict[str, Any] = {
                         "url": url,
+                        "method": method_upper,
                         "status": status,
                         "attempt": attempt,
                         "total_attempts": total_attempts,
@@ -369,15 +419,17 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
                     )
                     if attempt >= total_attempts:
                         _store_cache_miss(
-                            url,
+                            cache_key,
                             cfg,
                             reason,
                             last_failure_details,
+                            url=url,
                         )
                         logger.debug(
                             "request_fail",
                             url=url,
                             total_attempts=total_attempts,
+                            method=method_upper,
                             rps=cfg.rps,
                             status=status,
                             **details_excluding("status"),
@@ -402,15 +454,17 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
                         logger.info(
                             "request_invalid_identifier",
                             url=url,
+                            method=method_upper,
                             rps=cfg.rps,
                             status=status,
                             **details_excluding("status"),
                         )
                         _store_cache_miss(
-                            url,
+                            cache_key,
                             cfg,
                             "invalid_identifier",
                             last_failure_details,
+                            url=url,
                         )
                     else:
                         last_failure_details = {
@@ -420,6 +474,7 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
                         logger.warning(
                             "request_unexpected_status",
                             url=url,
+                            method=method_upper,
                             rps=cfg.rps,
                             status=status,
                             **details_excluding("status"),
@@ -428,6 +483,7 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
                         "request_fail",
                         url=url,
                         total_attempts=total_attempts,
+                        method=method_upper,
                         rps=cfg.rps,
                         status=status,
                         **details_excluding("status"),
@@ -436,7 +492,7 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
 
                 try:
                     response.raise_for_status()
-                    data = cast(dict[str, Any], response.json())
+                    response_data = cast(dict[str, Any], response.json())
                 except requests.RequestException as exc:  # pragma: no cover - network
                     last_failure_details = {
                         "reason": "response_error",
@@ -450,12 +506,14 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
                             error=str(exc),
                             attempt=attempt,
                             total_attempts=total_attempts,
+                            method=method_upper,
                             rps=cfg.rps,
                         )
                         logger.debug(
                             "request_fail",
                             url=url,
                             total_attempts=total_attempts,
+                            method=method_upper,
                             rps=cfg.rps,
                             status=status,
                             **details_excluding("status"),
@@ -472,6 +530,7 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
                     logger.warning(
                         "response_not_json",
                         url=url,
+                        method=method_upper,
                         rps=cfg.rps,
                         status=status,
                         **details_excluding("status"),
@@ -480,6 +539,7 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
                         "request_fail",
                         url=url,
                         total_attempts=total_attempts,
+                        method=method_upper,
                         rps=cfg.rps,
                         status=status,
                         **details_excluding("status"),
@@ -490,13 +550,20 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
                     "request_ok",
                     url=url,
                     status=status,
+                    method=method_upper,
                     rps=cfg.rps,
                 )
                 with _CACHE_LOCK:
                     cache = _ensure_cache(cfg.cache_ttl, cfg.cache_maxsize)
-                    cache[url] = _CacheEntry(payload=data, outcome="hit")
-                logger.debug("cache_set", url=url, rps=cfg.rps, status="hit")
-                return data
+                    cache[cache_key] = _CacheEntry(payload=response_data, outcome="hit")
+                logger.debug(
+                    "cache_set",
+                    url=url,
+                    rps=cfg.rps,
+                    status="hit",
+                    method=method_upper,
+                )
+                return response_data
         except requests.RequestException as exc:  # pragma: no cover - network
             last_failure_details = {
                 "reason": "network_error",
@@ -510,6 +577,7 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
                     error=str(exc),
                     attempt=attempt,
                     total_attempts=total_attempts,
+                    method=method_upper,
                     rps=cfg.rps,
                 )
                 logger.debug(
@@ -517,6 +585,7 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
                     url=url,
                     status=None,
                     total_attempts=total_attempts,
+                    method=method_upper,
                     rps=cfg.rps,
                     **details_excluding("status"),
                 )
@@ -539,7 +608,12 @@ def _ensure_cache(ttl: float, maxsize: int) -> TTLCache[str, _CacheEntry]:
 
 
 def _store_cache_miss(
-    url: str, cfg: PubChemCfg, outcome: str, details: dict[str, Any] | None = None
+    cache_key: str,
+    cfg: PubChemCfg,
+    outcome: str,
+    details: dict[str, Any] | None = None,
+    *,
+    url: str | None = None,
 ) -> None:
     """Persist a cached miss outcome for ``url`` including optional details."""
 
@@ -557,7 +631,7 @@ def _store_cache_miss(
                     base_backoff = max(base_backoff, hint_value)
                 else:
                     base_backoff = hint_value
-            existing = cache.get(url)
+            existing = cache.get(cache_key)
             if (
                 existing is not None
                 and not existing.is_hit
@@ -584,7 +658,7 @@ def _store_cache_miss(
                         "timeout_stored_at": stored_at,
                     }
                 )
-                cache[url] = _CacheEntry(
+                cache[cache_key] = _CacheEntry(
                     payload=None,
                     outcome=outcome,
                     details=details_data.copy(),
@@ -596,10 +670,10 @@ def _store_cache_miss(
                     if key != "timeout_stored_at"
                 }
             else:
-                cache.pop(url, None)
+                cache.pop(cache_key, None)
                 log_details = details_data.copy()
         else:
-            cache[url] = _CacheEntry(
+            cache[cache_key] = _CacheEntry(
                 payload=None,
                 outcome=outcome,
                 details=details_data.copy() if details_data else None,
@@ -607,7 +681,7 @@ def _store_cache_miss(
             cached = True
             log_details = details_data.copy()
     log_data: dict[str, Any] = {
-        "url": url,
+        "url": url or cache_key,
         "rps": cfg.rps,
         "status": "miss",
         "outcome": outcome,

--- a/tests/unit/test_pubchem_client.py
+++ b/tests/unit/test_pubchem_client.py
@@ -13,6 +13,7 @@ from library.config import PubChemCfg
 class _DummyResponse:
     status_code: int
     headers: dict[str, Any]
+    payload: dict[str, Any] | None = None
 
     def __enter__(self) -> "_DummyResponse":
         return self
@@ -26,16 +27,22 @@ class _DummyResponse:
         return False
 
     def json(self) -> dict[str, Any]:
-        return {}
+        return self.payload or {}
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"unexpected status {self.status_code}")
 
 
 class _DummySession:
     def __init__(self, response_factory: Callable[[], _DummyResponse]) -> None:
         self._response_factory = response_factory
-        self.calls: list[tuple[str, tuple[float, float]]] = []
+        self.calls: list[tuple[str, str, dict[str, Any]]] = []
 
-    def get(self, url: str, timeout: tuple[float, float]) -> _DummyResponse:
-        self.calls.append((url, timeout))
+    def request(
+        self, method: str, url: str, **kwargs: Any
+    ) -> _DummyResponse:
+        self.calls.append((method, url, kwargs))
         return self._response_factory()
 
 
@@ -73,12 +80,19 @@ def test_make_request__caches_server_error_results(
     first_result = pubchem.make_request(url, cfg)
 
     assert first_result is None
-    assert len(session.calls) == cfg.retries + 1
+    assert session.calls == [
+        (
+            "GET",
+            url,
+            {"timeout": (cfg.timeout_connect, cfg.timeout_read)},
+        )
+        for _ in range(cfg.retries + 1)
+    ]
     assert sleep_calls == [30.0]
     assert limiter.acquires == cfg.retries + 1
 
     cache = pubchem._ensure_cache(cfg.cache_ttl, cfg.cache_maxsize)
-    entry = cache.get(url)
+    entry = cache.get(pubchem._build_cache_key("GET", url))
     assert entry is not None
     assert entry.outcome == "server_error"
     assert entry.details == {"reason": "server_error", "status": 503, "retry_after": 30.0}
@@ -110,11 +124,17 @@ def test_make_request__invalid_identifier_cached(monkeypatch: pytest.MonkeyPatch
     result = pubchem.make_request(url, cfg)
 
     assert result is None
-    assert session.calls == [(url, (cfg.timeout_connect, cfg.timeout_read))]
+    assert session.calls == [
+        (
+            "GET",
+            url,
+            {"timeout": (cfg.timeout_connect, cfg.timeout_read)},
+        )
+    ]
     assert limiter.acquires == 1
 
     cache = pubchem._ensure_cache(cfg.cache_ttl, cfg.cache_maxsize)
-    entry = cache.get(url)
+    entry = cache.get(pubchem._build_cache_key("GET", url))
     assert entry is not None
     assert entry.outcome == "invalid_identifier"
     assert entry.details == {"reason": "invalid_identifier", "status": 400}
@@ -122,5 +142,56 @@ def test_make_request__invalid_identifier_cached(monkeypatch: pytest.MonkeyPatch
     second = pubchem.make_request(url, cfg)
 
     assert second is None
-    assert session.calls == [(url, (cfg.timeout_connect, cfg.timeout_read))]
+    assert session.calls == [
+        (
+            "GET",
+            url,
+            {"timeout": (cfg.timeout_connect, cfg.timeout_read)},
+        )
+    ]
     assert limiter.acquires == 1
+
+
+def test_get_cid_from_smiles__uses_post_for_stereochemistry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg = PubChemCfg()
+    smiles = r"C/C=C\C"
+
+    limiter = _DummyLimiter()
+    monkeypatch.setattr(pubchem, "get_limiter", lambda *_args, **_kwargs: limiter)
+
+    response_payload = {
+        "IdentifierList": {
+            "CID": ["123", "123", "456"],
+        }
+    }
+
+    session = _DummySession(lambda: _DummyResponse(200, {}, response_payload))
+    monkeypatch.setattr(pubchem, "get_session", lambda *_args, **_kwargs: session)
+    monkeypatch.setattr(pubchem, "_CACHE", None)
+
+    result = pubchem.get_cid_from_smiles(smiles, cfg)
+
+    assert result == "123|456"
+    assert session.calls == [
+        (
+            "POST",
+            f"{cfg.base.rstrip('/')}/compound/smiles/cids/JSON",
+            {
+                "timeout": (cfg.timeout_connect, cfg.timeout_read),
+                "data": {"smiles": smiles},
+            },
+        )
+    ]
+    assert limiter.acquires == 1
+
+    cache = pubchem._ensure_cache(cfg.cache_ttl, cfg.cache_maxsize)
+    cache_key = pubchem._build_cache_key(
+        "POST",
+        f"{cfg.base.rstrip('/')}/compound/smiles/cids/JSON",
+        {"smiles": smiles},
+    )
+    entry = cache.get(cache_key)
+    assert entry is not None
+    assert entry.is_hit


### PR DESCRIPTION
## Summary
- add a POST-based PubChem CID lookup for SMILES that include path separators and generalise the client cache key to cover method and payload
- extend the PubChem client request handling to log the HTTP method and persist negative cache entries with the new composite keys
- update the PubChem client unit tests with richer fakes and a regression for the new SMILES POST path

## Testing
- pytest tests/unit/test_pubchem_client.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e5f6876a948324a3868769f941df03