### PR TITLE
Improve git SHA resolution for GitHub Desktop shims

### DIFF
--- a/library/common/git.py
+++ b/library/common/git.py
@@ -13,7 +13,7 @@ import os
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterable
 
 from .log import logger
 
@@ -205,6 +205,61 @@ def _error_payload(error: BaseException) -> dict[str, Any]:
     return {"error": _format_error(error)}
 
 
+def _github_desktop_git_candidates(executable: Path) -> Iterable[str]:
+    """Yield potential real Git executables for GitHub Desktop shims."""
+
+    lower_path = str(executable).lower()
+    if "githubdesktop" not in lower_path:
+        return []
+
+    roots: set[Path] = {executable.parent}
+    for ancestor in executable.parents:
+        roots.add(ancestor)
+        if ancestor.name.lower() == "githubdesktop":
+            break
+
+    candidates: list[str] = []
+    for root in roots:
+        for app_dir in root.glob("app-*"):
+            candidate = app_dir / "resources" / "app" / "git" / "cmd" / "git.exe"
+            candidates.append(str(candidate))
+    return candidates
+
+
+def _candidate_git_commands(git_executable: str) -> Iterable[list[str]]:
+    """Yield Git command invocations to try in order."""
+
+    base_args = ["rev-parse", "HEAD"]
+    commands: list[list[str]] = []
+    seen: set[tuple[str, ...]] = set()
+
+    def _add(command: Iterable[str]) -> None:
+        cmd = [str(part) for part in command]
+        key = tuple(cmd)
+        if key not in seen:
+            seen.add(key)
+            commands.append(cmd)
+
+    _add([git_executable, *base_args])
+
+    exe_path = Path(git_executable)
+    exe_name = exe_path.name.lower()
+
+    if exe_path.suffix.lower() == ".exe":
+        for candidate in _github_desktop_git_candidates(exe_path):
+            _add([candidate, *base_args])
+        if os.name == "nt":
+            cmd_variant = exe_path.with_suffix(".cmd")
+            _add([str(cmd_variant), *base_args])
+
+    if exe_name not in {"git", "git.exe"}:
+        _add(["git", *base_args])
+    if os.name == "nt" and exe_name != "git.cmd":
+        _add(["git.cmd", *base_args])
+
+    return commands
+
+
 @functools.lru_cache(maxsize=1)
 def _git_sha() -> str:
     """Return the Git commit hash for the repository.
@@ -242,20 +297,34 @@ def _git_sha() -> str:
         logger.warning("git_executable_missing")
         return "UNKNOWN"
 
-    try:
-        result = subprocess.run(
-            [git_executable, "rev-parse", "HEAD"],
-            cwd=repo_root,
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-        return result.stdout.strip()
-    except (subprocess.CalledProcessError, UnicodeDecodeError, OSError) as exc:
-        fallback = _read_head_sha(git_dir)
-        if fallback is not None:
-            _log_fallback(fallback, reason="subprocess_error", error=exc)
-            return fallback
-        logger.warning("git_sha_unavailable", extra=_error_payload(exc))
+    errors: list[BaseException] = []
 
-        return "UNKNOWN"
+    for command in _candidate_git_commands(git_executable):
+        try:
+            result = subprocess.run(
+                command,
+                cwd=repo_root,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except (subprocess.CalledProcessError, UnicodeDecodeError, OSError) as exc:
+            errors.append(exc)
+            continue
+
+        output = result.stdout.strip()
+        if output:
+            return output
+
+    fallback = _read_head_sha(git_dir)
+    if fallback is not None:
+        error = errors[-1] if errors else None
+        _log_fallback(fallback, reason="subprocess_error", error=error)
+        return fallback
+
+    if errors:
+        logger.warning("git_sha_unavailable", extra=_error_payload(errors[-1]))
+    else:
+        logger.warning("git_sha_unavailable")
+
+    return "UNKNOWN"

--- a/tests/unit/test_git_utils.py
+++ b/tests/unit/test_git_utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib
 import logging
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -70,3 +71,66 @@ def test_git_sha__shared_singleton() -> None:
     legacy = importlib.import_module("library.git_utils")
 
     assert legacy._git_sha is common._git_sha
+
+
+@pytest.mark.unit
+def test_git_sha__github_desktop_fallback(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """GitHub Desktop shims should fall back to the bundled Git executable."""
+
+    module = importlib.import_module("library.common.git")
+
+    cache_clear = getattr(module._git_sha, "cache_clear", None)
+    if cache_clear is None:  # pragma: no cover - defensive guard
+        pytest.skip("_git_sha missing cache_clear helper")
+    cache_clear()
+
+    repo_root = tmp_path / "repo"
+    git_dir = repo_root / ".git"
+    repo_root.mkdir()
+    git_dir.mkdir()
+    (git_dir / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf8")
+    ref_dir = git_dir / "refs" / "heads"
+    ref_dir.mkdir(parents=True)
+    (ref_dir / "main").write_text("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\n", encoding="utf8")
+
+    desktop_root = tmp_path / "GitHubDesktop"
+    stub = desktop_root / "git.exe"
+    actual_git = (
+        desktop_root
+        / "app-3.3.0"
+        / "resources"
+        / "app"
+        / "git"
+        / "cmd"
+        / "git.exe"
+    )
+    desktop_root.mkdir()
+    actual_git.parent.mkdir(parents=True, exist_ok=True)
+    stub.touch()
+    actual_git.touch()
+
+    commands: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        commands.append(cmd)
+        if cmd[0] == str(stub):
+            raise subprocess.CalledProcessError(
+                returncode=4294967295,
+                cmd=cmd,
+                stderr="stub failed",
+            )
+        if cmd[0] == str(actual_git):
+            return subprocess.CompletedProcess(cmd, 0, stdout="deadbeef\n", stderr="")
+        raise AssertionError(f"Unexpected command: {cmd!r}")
+
+    monkeypatch.setattr(module, "_repo_root", lambda: repo_root)
+    monkeypatch.setattr(module.shutil, "which", lambda _: str(stub))
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    monkeypatch.delenv("GIT_SHA", raising=False)
+
+    sha = module._git_sha()
+
+    assert sha == "deadbeef"
+    assert [cmd[0] for cmd in commands] == [str(stub), str(actual_git)]
+
+    cache_clear()


### PR DESCRIPTION
## Summary
- extend the git SHA helper to try alternative commands when the GitHub Desktop shim fails, including the bundled Git binary
- ensure subprocess failures fall back gracefully while reusing the cached helper
- cover the GitHub Desktop shim scenario with a dedicated unit test

## Testing
- pytest tests/unit/test_git_utils.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e5f7b4a3048324b54ed09273914149