### PR TITLE
Improve git SHA resolution and logger handling

### DIFF
--- a/library/common/git.py
+++ b/library/common/git.py
@@ -233,12 +233,18 @@ def _git_sha() -> str:
         logger.info("git_directory_missing", path=str(repo_root))
         return "UNKNOWN"
 
+    # Prefer reading the SHA directly from the ``.git`` directory to avoid
+    # spawning subprocesses in environments where Git may be bundled without
+    # the required runtime dependencies (for example GitHub Desktop on
+    # Windows).  This keeps logging noise low while still providing the commit
+    # hash for packaged artefacts.
+    head_sha = _read_head_sha(git_dir)
+    if head_sha is not None:
+        logger.debug("git_sha_head", sha=head_sha)
+        return head_sha
+
     git_executable = shutil.which("git")
     if git_executable is None:
-        fallback = _read_head_sha(git_dir)
-        if fallback is not None:
-            _log_fallback(fallback, reason="missing_executable")
-            return fallback
         logger.warning("git_executable_missing")
         return "UNKNOWN"
 
@@ -250,12 +256,25 @@ def _git_sha() -> str:
             capture_output=True,
             text=True,
         )
-        return result.stdout.strip()
     except (subprocess.CalledProcessError, UnicodeDecodeError, OSError) as exc:
         fallback = _read_head_sha(git_dir)
         if fallback is not None:
             _log_fallback(fallback, reason="subprocess_error", error=exc)
             return fallback
         logger.warning("git_sha_unavailable", extra=_error_payload(exc))
-
         return "UNKNOWN"
+
+    sha = _ensure_text(result.stdout)
+    if sha is not None:
+        return sha
+
+    fallback = _read_head_sha(git_dir)
+    if fallback is not None:
+        _log_fallback(fallback, reason="empty_output")
+        return fallback
+
+    logger.warning(
+        "git_sha_unavailable",
+        extra={"error": "rev-parse returned empty output"},
+    )
+    return "UNKNOWN"

--- a/library/pipelines/testitem/pubchem.py
+++ b/library/pipelines/testitem/pubchem.py
@@ -64,6 +64,14 @@ def _load_pubchem_library():
     return pubchem_lib
 
 
+def __getattr__(name: str) -> Any:
+    """Provide lazy access to the legacy ``pl`` alias used in older tests."""
+
+    if name == "pl":
+        return _load_pubchem_library()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
 def _pubchem_session_signature(api_cfg: ApiCfg, retry_cfg: RetryCfg) -> str:
     """Return a stable signature for the PubChem session configuration."""
 

--- a/tests/e2e/test_get_cli_pipelines.py
+++ b/tests/e2e/test_get_cli_pipelines.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import importlib
 from collections import Counter
 from contextlib import contextmanager
 from pathlib import Path
@@ -81,6 +82,14 @@ class _MemoryLogger:
 def _patch_logger(monkeypatch: pytest.MonkeyPatch, module: object) -> _MemoryLogger:
     logger = _MemoryLogger()
     monkeypatch.setattr(module, "logger", logger)
+    try:
+        command_module_name = f"library.cli.commands.{module.__name__.split('.')[-1]}"
+        command_module = importlib.import_module(command_module_name)
+    except ModuleNotFoundError:
+        pass
+    else:
+        if hasattr(command_module, "logger"):
+            monkeypatch.setattr(command_module, "logger", logger)
     return logger
 
 

--- a/tests/unit/test_git_utils.py
+++ b/tests/unit/test_git_utils.py
@@ -63,6 +63,46 @@ def test_git_sha__missing_git_directory_logged_as_info(
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize("module_name", ["library.git_utils", "library.common.git"])
+def test_git_sha__prefers_head_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    module_name: str,
+) -> None:
+    """Reading ``HEAD`` directly should avoid spawning ``git`` subprocesses."""
+
+    module = importlib.import_module(module_name)
+
+    cache_clear = getattr(module._git_sha, "cache_clear", None)
+    if cache_clear is None:  # pragma: no cover - defensive guard
+        pytest.skip("_git_sha missing cache_clear helper")
+    cache_clear()
+
+    target_module = importlib.import_module(module._git_sha.__module__)
+
+    repo_root = tmp_path / "project"
+    git_dir = repo_root / ".git"
+    head_ref = git_dir / "refs" / "heads"
+    head_ref.mkdir(parents=True)
+
+    expected_sha = "3f87ce9ea06b4d28efddabd2203fbb1fee117a06"
+    (git_dir / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf8")
+    (head_ref / "main").write_text(f"{expected_sha}\n", encoding="utf8")
+
+    monkeypatch.setattr(target_module, "_repo_root", lambda: repo_root)
+
+    # ``subprocess.run`` must not be invoked when ``HEAD`` already yields a SHA.
+    def _unexpected_run(*_: object, **__: object) -> None:  # pragma: no cover - defensive
+        raise AssertionError("subprocess.run should not be called when HEAD is readable")
+
+    monkeypatch.setattr(target_module.subprocess, "run", _unexpected_run)
+
+    sha = module._git_sha()
+
+    assert sha == expected_sha
+
+
+@pytest.mark.unit
 def test_git_sha__shared_singleton() -> None:
     """Both modules should expose the same cached helper instance."""
 


### PR DESCRIPTION
## Summary
- prefer reading the cached HEAD commit hash before invoking `git` so Windows builds do not spam `git_sha_fallback`
- add coverage for the HEAD-first lookup and teach the CLI logger patch helper to stub command modules as well
- restore a lazy `pubchem.pl` compatibility alias so integration tests can monkeypatch the PubChem client

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e5f79101b0832490febf479d51b930