### PR TITLE
Improve git SHA resolution and logging hooks

### DIFF
--- a/library/cli/commands/get_activity_data.py
+++ b/library/cli/commands/get_activity_data.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
+import sys
 from pathlib import Path
 from time import perf_counter
 
@@ -82,6 +83,13 @@ def run_activity_pipeline(
 
     start_time = perf_counter()
 
+    active_logger = logger
+    script_module = sys.modules.get("scripts.get_activity_data")
+    if script_module is not None:
+        patched_logger = getattr(script_module, "logger", None)
+        if patched_logger is not None:
+            active_logger = patched_logger
+
     args = argparse.Namespace(
         input_csv=_normalise_path(options.input_csv),
         skip_existing=bool(options.skip_existing),
@@ -124,12 +132,12 @@ def run_activity_pipeline(
 
     batch_size = getattr(cfg.activity, "batch_size", None)
     if batch_size is not None and batch_size > MAX_ACTIVITY_CHUNK_SIZE:
-        logger.warning(
+        active_logger.warning(
             "activity_batch_size_clamped",
             configured=batch_size,
             limit=MAX_ACTIVITY_CHUNK_SIZE,
         )
-        logger.warning(
+        active_logger.warning(
             f"Configured batch size {batch_size} exceeds the hard cap of {MAX_ACTIVITY_CHUNK_SIZE}; "
             f"reducing to {MAX_ACTIVITY_CHUNK_SIZE}."
         )
@@ -138,12 +146,12 @@ def run_activity_pipeline(
 
     timeout = getattr(cfg.activity, "timeout", None)
     if timeout is not None and timeout < MIN_ACTIVITY_TIMEOUT:
-        logger.warning(
+        active_logger.warning(
             "activity_timeout_clamped",
             configured=timeout,
             minimum=MIN_ACTIVITY_TIMEOUT,
         )
-        logger.warning(
+        active_logger.warning(
             f"Configured timeout {timeout} is below the minimum of {MIN_ACTIVITY_TIMEOUT}; "
             f"increasing to {MIN_ACTIVITY_TIMEOUT}."
         )
@@ -156,11 +164,11 @@ def run_activity_pipeline(
 
     retry_attempts = getattr(cfg.retry, "max_attempts", None)
     if retry_attempts is not None and retry_attempts <= 1:
-        logger.warning(
+        active_logger.warning(
             "activity_retry_disabled",
             configured=retry_attempts,
         )
-        logger.warning(
+        active_logger.warning(
             "Configured system.retry.max_attempts=%s disables urllib3 retry handling; "
             "increase to at least 2 to tolerate transient network issues.",
             retry_attempts,
@@ -168,19 +176,19 @@ def run_activity_pipeline(
 
     api_retries = getattr(cfg.api, "retries", None)
     if api_retries is not None and api_retries <= 0:
-        logger.warning(
+        active_logger.warning(
             "activity_api_retry_disabled",
             configured=api_retries,
         )
-        logger.warning(
+        active_logger.warning(
             "Configured chembl.api.retries=%s disables client-level request retries; "
             "increase to 1 or more for resilience.",
             api_retries,
         )
 
     if args.skip_existing and output_path.exists() and not args.force:
-        logger.info("pipeline_skip_existing", output=str(output_path))
-        logger.info(
+        active_logger.info("pipeline_skip_existing", output=str(output_path))
+        active_logger.info(
             f"Skipping execution because '{output_path}' already exists and --force was not provided."
         )
         emit_completion_message(

--- a/library/common/git.py
+++ b/library/common/git.py
@@ -233,6 +233,11 @@ def _git_sha() -> str:
         logger.info("git_directory_missing", path=str(repo_root))
         return "UNKNOWN"
 
+    head_sha = _read_head_sha(git_dir)
+    if head_sha is not None:
+        logger.info("git_sha_head", sha=head_sha)
+        return head_sha
+
     git_executable = shutil.which("git")
     if git_executable is None:
         fallback = _read_head_sha(git_dir)

--- a/library/pipelines/testitem/pubchem.py
+++ b/library/pipelines/testitem/pubchem.py
@@ -64,6 +64,22 @@ def _load_pubchem_library():
     return pubchem_lib
 
 
+class _PubChemLibraryProxy:
+    """Proxy exposing ``library.integration.pubchem_library`` lazily."""
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(_load_pubchem_library(), name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        setattr(_load_pubchem_library(), name, value)
+
+    def __dir__(self) -> list[str]:  # pragma: no cover - debug helper
+        return sorted(set(dir(type(self)) + dir(_load_pubchem_library())))
+
+
+pl = _PubChemLibraryProxy()
+
+
 def _pubchem_session_signature(api_cfg: ApiCfg, retry_cfg: RetryCfg) -> str:
     """Return a stable signature for the PubChem session configuration."""
 
@@ -880,4 +896,5 @@ __all__ = [
     "add_pubchem_data",
     "augment_pubchem",
     "resolve_pubchem_cid",
+    "pl",
 ]

--- a/tests/unit/test_git_utils.py
+++ b/tests/unit/test_git_utils.py
@@ -63,6 +63,53 @@ def test_git_sha__missing_git_directory_logged_as_info(
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize("module_name", ["library.git_utils", "library.common.git"])
+def test_git_sha__prefers_head_file_over_subprocess(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    module_name: str,
+) -> None:
+    """Reading ``HEAD`` directly should avoid invoking the Git executable."""
+
+    module = importlib.import_module(module_name)
+
+    cache_clear = getattr(module._git_sha, "cache_clear", None)
+    if cache_clear is None:  # pragma: no cover - defensive guard
+        pytest.skip("_git_sha missing cache_clear helper")
+    cache_clear()
+
+    target_module = importlib.import_module(module._git_sha.__module__)
+
+    monkeypatch.setattr(target_module, "_repo_root", lambda: tmp_path)
+
+    git_dir = tmp_path / ".git"
+    ref_dir = git_dir / "refs" / "heads"
+    ref_dir.mkdir(parents=True)
+
+    sha = "a" * 40
+    (git_dir / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf8")
+    (ref_dir / "main").write_text(f"{sha}\n", encoding="utf8")
+
+    def _fail_git(*args: object, **kwargs: object) -> None:
+        raise AssertionError("git executable should not be invoked")
+
+    monkeypatch.setattr(target_module.shutil, "which", lambda _: "git")
+    monkeypatch.setattr(target_module.subprocess, "run", _fail_git)
+
+    caplog.set_level(logging.DEBUG, logger="chembl")
+
+    result = module._git_sha()
+
+    assert result == sha
+
+    head_logs = [
+        record for record in caplog.records if "git_sha_head" in record.message
+    ]
+    assert head_logs, "expected git_sha_head log entry"
+
+
+@pytest.mark.unit
 def test_git_sha__shared_singleton() -> None:
     """Both modules should expose the same cached helper instance."""
 


### PR DESCRIPTION
## Summary
- prefer the cached .git/HEAD when resolving the commit SHA and add unit coverage for the fast-path
- ensure the activity pipeline CLI honours patched loggers when skip-existing short-circuits
- expose a lazy pubchem library proxy so tests can patch `pubchem.pl`

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e5f6bf51d88324bf67ecdda4d0fc15