### PR TITLE
Validate CLI limit argument

### DIFF
--- a/library/utils/cli_tools/get_activities.py
+++ b/library/utils/cli_tools/get_activities.py
@@ -24,9 +24,15 @@ def parse_args(
     def _limit(value: str) -> int:
         """Return ``value`` validated as a non-negative integer."""
 
-        if value == "0":
-            return 0
-        return cli.positive_int(value)
+        try:
+            parsed = int(value)
+        except ValueError as exc:  # pragma: no cover - handled by argparse
+            raise argparse.ArgumentTypeError(
+                "limit must be a non-negative integer"
+            ) from exc
+        if parsed < 0:
+            raise argparse.ArgumentTypeError("limit must be a non-negative integer")
+        return parsed
 
     parser.add_argument(
         "--limit",

--- a/tests/unit/scripts/test_get_activities_cli.py
+++ b/tests/unit/scripts/test_get_activities_cli.py
@@ -129,3 +129,12 @@ def test_main__dry_run_skips_fetch(
     assert called["value"] is False
     assert writer_calls == []
     assert ("info", "dry_run", {"limit": 5}) in logger_stub.events
+
+
+@pytest.mark.unit
+def test_parse_args__invalid_limit_error_message(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit):
+        get_activities.parse_args(["--limit", "-1"])
+
+    captured = capsys.readouterr()
+    assert "limit must be a non-negative integer" in captured.err


### PR DESCRIPTION
## Summary
- validate the get_activities limit argument locally without relying on cli.positive_int
- ensure negative inputs raise argparse.ArgumentTypeError with a clear message
- cover the failure case with a unit test that checks the emitted error text

## Testing
- pytest tests/unit/scripts/test_get_activities_cli.py::test_parse_args__invalid_limit_error_message -q

------
https://chatgpt.com/codex/tasks/task_e_68e6043a6f088324952dcbbd2e1faa4e