### PR TITLE
Validate synthetic activities and trigger table QA

### DIFF
--- a/library/utils/cli_tools/get_activities.py
+++ b/library/utils/cli_tools/get_activities.py
@@ -12,6 +12,16 @@ from library import cli, io
 from library.common.log import logger
 from library.config import Config, ConfigError, ensure_dirs, print_config
 from library.pipelines.activity import get_activities
+from library.qa.reporting import build_table_quality_hook
+from library.validation import validate_activities
+
+
+_REQUIRED_ACTIVITY_COLUMNS: dict[str, str] = {
+    "activity_id": "Int64",
+    "molecule_chembl_id": "string",
+    "assay_chembl_id": "string",
+    "standard_value": "Float64",
+}
 
 
 def parse_args(
@@ -51,7 +61,16 @@ def _frame_from_records(records: Iterable[dict[str, object]]) -> pd.DataFrame:
 
     frame = pd.DataFrame(list(records))
     if frame.empty:
-        return pd.DataFrame(columns=["activity_id"], dtype="Int64")
+        return pd.DataFrame(
+            {column: pd.Series(dtype=dtype) for column, dtype in _REQUIRED_ACTIVITY_COLUMNS.items()}
+        )
+
+    for column, dtype in _REQUIRED_ACTIVITY_COLUMNS.items():
+        if column not in frame.columns:
+            frame[column] = pd.Series(pd.NA, index=frame.index, dtype=dtype)
+        else:
+            frame[column] = frame[column].astype(dtype)
+
     return frame
 
 
@@ -82,6 +101,20 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
         logger.error("invalid_arguments", error=str(exc))
         return 1
 
+    try:
+        validation = validate_activities(frame, return_result=True)
+    except Exception as exc:
+        logger.error("validation_error", error=str(exc))
+        return 1
+
+    failure_cases = getattr(validation, "failure_cases", None)
+    if failure_cases is not None and not failure_cases.empty:
+        failures = len(failure_cases) if hasattr(failure_cases, "__len__") else 0
+        logger.error("validation_failed", failures=int(failures))
+        return 1
+
+    frame = getattr(validation, "data", frame)
+
     output_candidate = getattr(args, "output_csv", None)
     input_candidate = getattr(args, "input_csv", None)
     if output_candidate in (None, argparse.SUPPRESS):
@@ -93,6 +126,12 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
         output_path = Path(output_candidate)
 
     written_path = _write_output(frame, output_path, cfg=cfg)
+    table_quality = build_table_quality_hook(
+        getattr(getattr(cfg, "system", None), "doc_quality", None),
+        table_name=written_path.with_suffix(""),
+        destination=written_path.parent,
+    )
+    table_quality(written_path)
     logger.info(
         "activity_generated",
         count=int(frame.shape[0]),

--- a/tests/unit/scripts/test_get_activities_cli.py
+++ b/tests/unit/scripts/test_get_activities_cli.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
+import pandas as pd
 
 from library.utils.cli_tools import get_activities
+from library.config import Config
 
 
 class _LoggerStub:
@@ -129,3 +132,95 @@ def test_main__dry_run_skips_fetch(
     assert called["value"] is False
     assert writer_calls == []
     assert ("info", "dry_run", {"limit": 5}) in logger_stub.events
+
+
+@pytest.mark.unit
+def test_run__validation_error_returns_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = Config()
+    output_csv = tmp_path / "activities.csv"
+    args = SimpleNamespace(
+        limit=3,
+        dry_run=False,
+        output_csv=output_csv,
+        input_csv=None,
+    )
+
+    monkeypatch.setattr(
+        get_activities,
+        "get_activities",
+        lambda limit: [{"activity_id": idx} for idx in range(limit)],
+    )
+
+    def _fail_validation(_: pd.DataFrame, *, return_result: bool) -> object:
+        raise ValueError("broken")
+
+    monkeypatch.setattr(get_activities, "validate_activities", _fail_validation)
+
+    table_quality_calls: list[object] = []
+
+    def _noop_quality(*_args: object, **_kwargs: object):
+        table_quality_calls.append(None)
+        return lambda *_a, **_k: None
+
+    monkeypatch.setattr(get_activities, "build_table_quality_hook", _noop_quality)
+
+    exit_code = get_activities.run(cfg, args)
+
+    assert exit_code == 1
+    assert table_quality_calls == []
+
+
+@pytest.mark.unit
+def test_run__table_quality_invoked_after_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = Config()
+    output_csv = tmp_path / "activities.csv"
+    args = SimpleNamespace(
+        limit=2,
+        dry_run=False,
+        output_csv=output_csv,
+        input_csv=None,
+    )
+
+    records = [
+        {
+            "activity_id": 0,
+            "molecule_chembl_id": "CHEMBL0",
+            "assay_chembl_id": "ASSAY0",
+            "standard_value": 1.0,
+        },
+        {
+            "activity_id": 1,
+            "molecule_chembl_id": "CHEMBL1",
+            "assay_chembl_id": "ASSAY1",
+            "standard_value": 2.0,
+        },
+    ]
+
+    monkeypatch.setattr(get_activities, "get_activities", lambda limit: records[:limit])
+
+    observed: dict[str, object] = {}
+
+    def _build_quality(cfg_section, *, table_name, destination):
+        observed["cfg"] = cfg_section
+        observed["table_name"] = table_name
+        observed["destination"] = destination
+
+        def _hook(subject: object) -> None:
+            observed["subject"] = subject
+
+        return _hook
+
+    monkeypatch.setattr(get_activities, "build_table_quality_hook", _build_quality)
+
+    exit_code = get_activities.run(cfg, args)
+
+    assert exit_code == 0
+    assert output_csv.exists()
+    assert observed["cfg"] == cfg.system.doc_quality
+    assert observed["subject"] == output_csv
+    assert observed["table_name"] == output_csv.with_suffix("")
+    assert observed["destination"] == output_csv.parent


### PR DESCRIPTION
## Summary
- ensure the synthetic activities CLI produces schema-compatible frames, validates them, and calls the table-quality hook
- add unit coverage for validation failures and quality hook execution

## Testing
- pytest tests/unit/scripts/test_get_activities_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68e604368b9c832499370f092dec2e20