### PR TITLE
Align get-activities CLI with activity_id default

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ python scripts/get_data.py \
 | Tissue | `python scripts/get_tissue_data.py --input data/input/tissue.csv --final-out output/tissues.csv --chunk-size 50 --xref-sources uberon,efo,bto` | Resolves tissue metadata, merges ontology cross-references and normalises synonyms for downstream joins. Run separately before `get_activity_data` when tissue lookups are required. |
 | Cell line | `python scripts/get_cellline_data.py --input data/input/cellline.csv --final-out output/cellline.csv --batch-size 20 --limit 100` | Retrieves ChEMBL cell line records, normalises nullable identifiers and enforces deterministic ordering. |
 | Activity | `python scripts/get_activity_data.py --input data/input/activity.csv --final-out output/activities.csv --timeout 120 --limit 500 --offset 100 --workers 4 --dry-run` | Flags: `--timeout`, `--limit`, `--offset`, `--dry-run`, `--workers`. |
-| Synthetic activities | `python scripts/get_activities.py --limit 25 --dry-run` | Generates deterministic dummy rows for smoke tests; accepts the same logging flags as other CLI tools. |
+| Synthetic activities | `python scripts/get_activities.py --limit 25 --dry-run` | Generates deterministic dummy rows for smoke tests; defaults to the `activity_id` column and accepts the same logging flags as other CLI tools. |
 
 Each pipeline writes a deterministic CSV, a `<name>.meta.yaml` metadata sidecar
 and table-quality reports under the same directory. The target pipeline also

--- a/docs/en/guides/USAGE.md
+++ b/docs/en/guides/USAGE.md
@@ -251,8 +251,8 @@ Use these modules for diagnostics, QA, or offline workflows. Each exposes a
 | `library.utils.cli_tools.chunk_io_main` | `chunk-io --input data.csv --final-out copy.csv` | Re-serialise CSV files in deterministic chunks. |
 | `library.utils.cli_tools.csv_utils_main` | `csv-utils --input data.csv --final-out clean.csv --sep ,` | Normalise delimiters, quoting, and ordering for arbitrary CSV files. |
 | `library.utils.cli_tools.dtype_inspector_main` | `python -m library.utils.cli_tools.dtype_inspector_main` | Inspect pandas dtypes produced by the pipelines. |
-| `library.utils.cli_tools.get_activities` | `python scripts/get_activities.py --limit 10 --dry-run` | Emit synthetic activity rows to verify logging and CLI wiring. |
-| `library.utils.cli_tools.get_activities` | `get-activities --limit 10 --output-csv output/activities_smoke.csv` | Emit synthetic activity rows and write deterministic CSV + `.meta.yaml` artefacts for smoke verification. |
+| `library.utils.cli_tools.get_activities` | `python scripts/get_activities.py --limit 10 --dry-run` | Emit synthetic activity rows to verify logging and CLI wiring; defaults to the `activity_id` column. |
+| `library.utils.cli_tools.get_activities` | `get-activities --limit 10 --output-csv output/activities_smoke.csv` | Emit synthetic activity rows and write deterministic CSV + `.meta.yaml` artefacts for smoke verification; defaults to the `activity_id` column. |
 | `library.utils.cli_tools.get_document_type` | `get-document-type --input docs.csv` | Apply the bundled publication-type heuristics. |
 | `library.utils.cli_tools.get_input_initialisation` | `get-input-initialisation --same-doc init.xlsx --all-doc pairs.xlsx` | Combine Excel workbooks into canonical entity/relationship tables. |
 | `library.utils.cli_tools.mapper_main` | `mapper --input ids.csv --final-out mapped.csv --column target_chembl_id` | Interactive mapper for quick lookups. |

--- a/docs/ru/guides/USAGE.md
+++ b/docs/ru/guides/USAGE.md
@@ -242,8 +242,8 @@ get-testitem-data --input data/input/testitem.csv \
 | `library.utils.cli_tools.chunk_io_main` | `chunk-io --input data.csv --final-out copy.csv` | Потоковое чтение/запись CSV с сохранением порядка. |
 | `library.utils.cli_tools.csv_utils_main` | `csv-utils --input data.csv --final-out clean.csv --sep ,` | Нормализация разделителей, кавычек и порядка колонок. |
 | `library.utils.cli_tools.dtype_inspector_main` | `python -m library.utils.cli_tools.dtype_inspector_main` | Диагностика типов pandas-таблиц. |
-| `library.utils.cli_tools.get_activities` | `python scripts/get_activities.py --limit 10 --dry-run` | Генерация тестовых активностей для проверки логов и CLI. |
-| `library.utils.cli_tools.get_activities` | `get-activities --limit 10 --output-csv output/activities_smoke.csv` | Генерация тестовых активностей с записью детерминированного CSV и `.meta.yaml` для smoke-проверок. |
+| `library.utils.cli_tools.get_activities` | `python scripts/get_activities.py --limit 10 --dry-run` | Генерация тестовых активностей для проверки логов и CLI; по умолчанию используется колонка `activity_id`. |
+| `library.utils.cli_tools.get_activities` | `get-activities --limit 10 --output-csv output/activities_smoke.csv` | Генерация тестовых активностей с записью детерминированного CSV и `.meta.yaml` для smoke-проверок; по умолчанию используется колонка `activity_id`. |
 | `library.utils.cli_tools.get_document_type` | `get-document-type --input docs.csv` | Применение встроенных правил классификации публикаций. |
 | `library.utils.cli_tools.get_input_initialisation` | `get-input-initialisation --same-doc init.xlsx --all-doc pairs.xlsx` | Объединение Excel-книг инициализации. |
 | `library.utils.cli_tools.mapper_main` | `mapper --input ids.csv --final-out mapped.csv --column target_chembl_id` | Интерактивный маппер UniProt/ChEMBL. |

--- a/library/cli/parser.py
+++ b/library/cli/parser.py
@@ -244,7 +244,7 @@ def build_parser(
     parser.add_argument(
         "--column",
         default=column,
-        help="Identifier column in input CSV",
+        help=f"Identifier column in input CSV (default: {column})",
     )
     parser.add_argument(
         size_option,

--- a/library/utils/cli_tools/get_activities.py
+++ b/library/utils/cli_tools/get_activities.py
@@ -19,7 +19,9 @@ def parse_args(
 ) -> tuple[argparse.ArgumentParser, argparse.Namespace, cli.LoggerConfig]:
     """Return parser, parsed arguments and logging configuration."""
 
-    parser, log_cfg = cli.build_parser("Generate dummy activity data", column="id")
+    parser, log_cfg = cli.build_parser(
+        "Generate dummy activity data", column="activity_id"
+    )
 
     def _limit(value: str) -> int:
         """Return ``value`` validated as a non-negative integer."""

--- a/tests/unit/scripts/test_get_activities_cli.py
+++ b/tests/unit/scripts/test_get_activities_cli.py
@@ -31,7 +31,7 @@ def test_main__limit_forwarded_to_pipeline(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     input_csv = tmp_path / "input.csv"
-    input_csv.write_text("id\nCHEMBL1\n", encoding="utf-8")
+    input_csv.write_text("activity_id\nCHEMBL1\n", encoding="utf-8")
     output_csv = tmp_path / "output.csv"
 
     observed: dict[str, int] = {}
@@ -85,7 +85,7 @@ def test_main__dry_run_skips_fetch(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     input_csv = tmp_path / "input.csv"
-    input_csv.write_text("id\nCHEMBL1\n", encoding="utf-8")
+    input_csv.write_text("activity_id\nCHEMBL1\n", encoding="utf-8")
     output_csv = tmp_path / "output.csv"
 
     called: dict[str, bool] = {"value": False}


### PR DESCRIPTION
## Summary
- set the get-activities helper to default to the `activity_id` column and clarify the generated help text
- refresh CLI quick reference documentation to mention the `activity_id` default for synthetic activities
- update the synthetic activities CLI unit tests to use the new column name

## Testing
- `pytest tests/unit/scripts/test_get_activities_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_68e604411a088324bd33f8cbc360ee31