### PR TITLE
Ensure molecule pref name fields are deduplicated

### DIFF
--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -715,10 +715,11 @@ def _ensure_molecule_pref_name(
             pending.append(cache_key)
 
     if pending:
-        fields = list(cfg.testitem.fields)
-        for column in ("molecule_chembl_id", "pref_name"):
-            if column not in fields:
-                fields.append(column)
+        fields = ["molecule_chembl_id", "pref_name"]
+        extra_fields = getattr(cfg.testitem, "fields", None)
+        if extra_fields:
+            fields.extend(extra_fields)
+        fields = sorted(set(fields))
         api_overrides: dict[str, Any] = {}
         if getattr(cfg.testitem, "retries", None) is not None:
             api_overrides["retries"] = cfg.testitem.retries

--- a/tests/unit/test_get_activity_data.py
+++ b/tests/unit/test_get_activity_data.py
@@ -297,6 +297,66 @@ def test_ensure_molecule_pref_name__applies_testitem_retry_overrides(monkeypatch
     )
 
 
+def test_ensure_molecule_pref_name__requests_minimal_field_set(monkeypatch) -> None:
+    cfg = SimpleNamespace(
+        api=_ApiStub(),
+        testitem=SimpleNamespace(
+            fields=["molecule_chembl_id", "pref_name", "molecule_properties"],
+            batch_size=2,
+            timeout=5.0,
+            request_limit=5,
+            retries=None,
+            backoff_factor=None,
+        ),
+    )
+
+    frame = _make_pref_name_frame()
+    cache: dict[str, str | None] = {}
+    cache_lock = Lock()
+    captured_fields: list[Sequence[str]] = []
+
+    def fake_get_testitem(
+        identifiers: Sequence[str],
+        *,
+        cfg,
+        client,
+        chunk_size,
+        timeout,
+        fields,
+        page_limit,
+    ) -> pd.DataFrame:
+        captured_fields.append(tuple(fields))
+        return pd.DataFrame(
+            {
+                "molecule_chembl_id": pd.Series(
+                    [str(identifier) for identifier in identifiers], dtype="string"
+                ),
+                "pref_name": pd.Series(
+                    [f"name-{identifier}" for identifier in identifiers], dtype="string"
+                ),
+            }
+        )
+
+    monkeypatch.setattr(get_activity_data.cl, "get_testitem", fake_get_testitem)
+
+    enriched = get_activity_data._ensure_molecule_pref_name(
+        frame,
+        cfg=cfg,
+        client=object(),
+        cache=cache,
+        cache_lock=cache_lock,
+    )
+
+    assert captured_fields == [
+        ("molecule_chembl_id", "molecule_properties", "pref_name")
+    ]
+
+    expected_series = pd.Series(["name-CHEMBL1", "name-CHEMBL2"], dtype="string")
+    pd.testing.assert_series_equal(
+        enriched["molecule_pref_name"], expected_series, check_names=False
+    )
+
+
 @pytest.mark.parametrize(
     "skip_existing, force, explicit_output, has_existing, expected_calls",
     [


### PR DESCRIPTION
## Summary
- default the Chembl test item lookup to request molecule identifiers and preferred names
- merge configured field overrides and remove duplicates before invoking the client
- add a regression test ensuring only the minimal field set is requested

## Testing
- `pytest tests/unit/test_get_activity_data.py -k minimal_field --maxfail=1 -q`


------
https://chatgpt.com/codex/tasks/task_e_68e6121c7fd483248545aa0304928f50