### PR TITLE
Simplify get_activities CLI parser

### DIFF
--- a/library/utils/cli_tools/get_activities.py
+++ b/library/utils/cli_tools/get_activities.py
@@ -10,7 +10,13 @@ import pandas as pd
 
 from library import cli, io
 from library.common.log import logger
-from library.config import Config, ConfigError, ensure_dirs, print_config
+from library.config import (
+    Config,
+    ConfigError,
+    DEFAULT_CONFIG_PATH,
+    ensure_dirs,
+    print_config,
+)
 from library.pipelines.activity import get_activities
 
 
@@ -19,9 +25,21 @@ def parse_args(
 ) -> tuple[argparse.ArgumentParser, argparse.Namespace, cli.LoggerConfig]:
     """Return parser, parsed arguments and logging configuration."""
 
-    parser, log_cfg = cli.build_parser(
-        "Generate dummy activity data", column="activity_id"
+    parser = argparse.ArgumentParser(description="Generate dummy activity data")
+    cli.add_common_arguments(parser)
+    parser.add_argument(
+        "--config",
+        dest="config",
+        type=cli.path_argument,
+        default=DEFAULT_CONFIG_PATH,
+        help=f"YAML configuration file (default: {DEFAULT_CONFIG_PATH})",
     )
+    parser.add_argument(
+        "--print-config",
+        action="store_true",
+        help="Print effective configuration and exit",
+    )
+    log_cfg = cli.create_logger_config(parser.get_default("log_level"))
 
     def _limit(value: str) -> int:
         """Return ``value`` validated as a non-negative integer."""

--- a/tests/unit/scripts/test_get_activities_cli.py
+++ b/tests/unit/scripts/test_get_activities_cli.py
@@ -138,3 +138,11 @@ def test_parse_args__invalid_limit_error_message(capsys: pytest.CaptureFixture[s
 
     captured = capsys.readouterr()
     assert "limit must be a non-negative integer" in captured.err
+
+
+@pytest.mark.unit
+def test_parse_args__only_expected_options_present() -> None:
+    _parser, args, _log_cfg = get_activities.parse_args([])
+
+    assert "chunk_size" not in vars(args)
+    assert "column" not in vars(args)


### PR DESCRIPTION
## Summary
- replace the get_activities CLI parser with a minimal variant that only exposes the required options
- keep the CLI help focused on the supported flags and reuse the shared common arguments
- extend the unit tests to ensure unused parser attributes are not returned

## Testing
- pytest tests/unit/scripts/test_get_activities_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68e612169a888324972b2cee6d1b25cb