### PR TITLE
Add adaptive wait to rate limiter and cover concurrency

### DIFF
--- a/library/common/rate_limiter.py
+++ b/library/common/rate_limiter.py
@@ -19,6 +19,10 @@ from cachetools import TTLCache
 GLOBAL_LIMITER_NAME = "system_global"
 
 
+_MIN_WAIT_SECONDS = 1e-3
+_MAX_WAIT_SECONDS = 5.0
+
+
 class RateLimiter:
     """Token bucket rate limiter.
 
@@ -38,15 +42,25 @@ class RateLimiter:
         self._lock = threading.Lock()
 
     def acquire(self) -> None:
-        """Block until a token is available."""
+        """Block until a token is available.
+
+        The wait strategy uses an adaptive back-off that doubles the minimum
+        sleep duration on every retry until a reasonable upper bound is
+        reached.  This approach keeps the loop responsive for highly
+        contended call sites (including concurrent threads) while guaranteeing
+        forward progress even when the system scheduler undersleeps.
+        """
         if self.rps <= 0:
             return
 
+        base_wait = max(1.0 / self.rps, _MIN_WAIT_SECONDS)
+        max_wait = max(base_wait, _MAX_WAIT_SECONDS)
+        adaptive_wait = base_wait
         wait = 0.0
+
         while True:
             if wait > 0:
                 sleep(wait)
-                wait = 0.0
 
             with self._lock:
                 now = time.monotonic()
@@ -59,8 +73,10 @@ class RateLimiter:
                     self._updated = now
                     return
 
-                min_interval = 1.0 / self.rps
-                wait = max(min_interval, (1 - self._tokens) / self.rps)
+                required = max(0.0, (1 - self._tokens) / self.rps)
+                wait = min(max(required, adaptive_wait), max_wait)
+
+            adaptive_wait = min(adaptive_wait * 2, max_wait)
 
 
 _limiters: TTLCache[str, RateLimiter] = TTLCache(maxsize=128, ttl=600)

--- a/tests/unit/test_rate_limiter.py
+++ b/tests/unit/test_rate_limiter.py
@@ -1,0 +1,96 @@
+"""Tests for :mod:`library.common.rate_limiter`."""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Callable
+
+import pytest
+
+from library.common import rate_limiter
+
+
+class _FakeClock:
+    """Deterministic clock used to fake :func:`time.monotonic` and sleeps."""
+
+    def __init__(self, *, factor: float = 1.0) -> None:
+        self._factor = factor
+        self._now = 0.0
+        self._lock = threading.Lock()
+        self.calls: list[float] = []
+
+    def monotonic(self) -> float:
+        with self._lock:
+            return self._now
+
+    def sleep(self, delay: float) -> None:
+        with self._lock:
+            self.calls.append(delay)
+            self._now += delay * self._factor
+        # Yield control to allow other threads to progress in tests using
+        # real threading primitives.
+        time.sleep(0)
+
+    def reset(self) -> None:
+        with self._lock:
+            self._now = 0.0
+            self.calls.clear()
+
+
+def _install_clock(monkeypatch: pytest.MonkeyPatch, clock: _FakeClock) -> None:
+    """Patch the rate limiter to use *clock* for time keeping."""
+
+    monkeypatch.setattr(rate_limiter.time, "monotonic", clock.monotonic)
+    monkeypatch.setattr(rate_limiter, "sleep", clock.sleep)
+
+
+@pytest.mark.unit
+def test_rate_limiter__adaptive_wait_increases_to_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The adaptive wait grows until capped when progress is slow."""
+
+    clock = _FakeClock(factor=0.01)
+    _install_clock(monkeypatch, clock)
+
+    limiter = rate_limiter.RateLimiter(rps=1.0, burst=1)
+    limiter.acquire()  # consume the initial burst token
+
+    clock.reset()
+    limiter.acquire()
+
+    assert len(clock.calls) > 3
+    assert clock.calls == sorted(clock.calls)
+    assert clock.calls[0] == pytest.approx(1.0)
+    assert clock.calls[-1] == pytest.approx(rate_limiter._MAX_WAIT_SECONDS)
+
+
+@pytest.mark.unit
+def test_rate_limiter__parallel_threads_make_progress(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Concurrent callers all acquire a token without stalling indefinitely."""
+
+    clock = _FakeClock()
+    _install_clock(monkeypatch, clock)
+
+    limiter = rate_limiter.RateLimiter(rps=2.0, burst=1)
+    acquire_times: list[float] = []
+    acquire_lock = threading.Lock()
+
+    def _worker(record: Callable[[float], None]) -> None:
+        limiter.acquire()
+        record(clock.monotonic())
+
+    def _record(timestamp: float) -> None:
+        with acquire_lock:
+            acquire_times.append(timestamp)
+
+    threads = [threading.Thread(target=_worker, args=(_record,)) for _ in range(3)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=1)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert len(acquire_times) == 3
+    assert acquire_times == sorted(acquire_times)
+    assert acquire_times[0] == pytest.approx(0.0)
+    assert acquire_times[-1] == pytest.approx(sum(clock.calls))


### PR DESCRIPTION
## Summary
- add an adaptive back-off strategy to the token bucket rate limiter to guarantee progress under contention
- document the behaviour in the rate limiter docstring for clarity
- add deterministic unit tests that exercise slow progress and parallel access scenarios

## Testing
- pytest -q tests/unit/test_rate_limiter.py

------
https://chatgpt.com/codex/tasks/task_e_68e61219f6d08324921c104259b5e781