### PR TITLE
Fix merge_series_prefer_left alignment for duplicate indices

### DIFF
--- a/library/common/pandas_utils.py
+++ b/library/common/pandas_utils.py
@@ -121,14 +121,43 @@ def merge_series_prefer_left(left: pd.Series, right: pd.Series) -> pd.Series:
     if left.empty and right.empty:
         return left.copy()
 
-    if not left.index.equals(right.index):
-        right = right.reindex(left.index)
+    original_index = left.index
 
-    result = left.copy()
+    left_work = left.copy()
+    right_work = right.copy()
+
+    if not original_index.equals(right.index):
+        left_work = _ensure_unique_index(left_work, always_multi=True)
+        right_work = _ensure_unique_index(right_work, always_multi=True)
+        right_work = right_work.reindex(left_work.index)
+
+    result = left_work.copy()
     missing_mask = result.isna()
     if missing_mask.any():
-        result.loc[missing_mask] = right.loc[missing_mask]
+        result.loc[missing_mask] = right_work.loc[missing_mask]
+
+    if isinstance(result.index, pd.MultiIndex):
+        result.index = original_index
     return result
+
+
+def _ensure_unique_index(series: pd.Series, *, always_multi: bool = False) -> pd.Series:
+    """Return ``series`` with a unique index preserving order.
+
+    Pandas disallows :meth:`Series.reindex` when the axis contains duplicate
+    labels. To align two series that may include duplicates we temporarily
+    promote their index to a ``MultiIndex`` made of the original label and a
+    per-label counter. The original order is preserved which allows a
+    positionally stable alignment.
+    """
+
+    if series.index.is_unique and not always_multi:
+        return series.copy()
+
+    counts = series.groupby(level=0).cumcount()
+    unique = series.copy()
+    unique.index = pd.MultiIndex.from_arrays([series.index, counts])
+    return unique
 
 
 __all__ = ["json_normalize_pyarrow", "merge_series_prefer_left", "read_csv_pyarrow"]

--- a/tests/unit/test_pandas_utils.py
+++ b/tests/unit/test_pandas_utils.py
@@ -1,0 +1,37 @@
+"""Tests for :mod:`library.common.pandas_utils`."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from library.common.pandas_utils import merge_series_prefer_left
+
+
+def test_merge_series_prefer_left__fills_missing_with_duplicate_index():
+    left = pd.Series([None, "kept"], index=["CHEMBL1", "CHEMBL1"])
+    right = pd.Series(["fallback"], index=["CHEMBL1"])
+
+    result = merge_series_prefer_left(left, right)
+
+    expected = pd.Series(["fallback", "kept"], index=["CHEMBL1", "CHEMBL1"])
+    pd.testing.assert_series_equal(result, expected)
+
+
+def test_merge_series_prefer_left__preserves_order_for_multiple_matches():
+    left = pd.Series([None, None, "base"], index=["A", "A", "B"])
+    right = pd.Series(["first", "second", "fallback"], index=["A", "A", "B"])
+
+    result = merge_series_prefer_left(left, right)
+
+    expected = pd.Series(["first", "second", "base"], index=["A", "A", "B"])
+    pd.testing.assert_series_equal(result, expected)
+
+
+def test_merge_series_prefer_left__ignores_extra_right_rows():
+    left = pd.Series([None], index=["X"])
+    right = pd.Series(["fill", "extra"], index=["X", "X"])
+
+    result = merge_series_prefer_left(left, right)
+
+    expected = pd.Series(["fill"], index=["X"])
+    pd.testing.assert_series_equal(result, expected)


### PR DESCRIPTION
## Summary
- ensure `merge_series_prefer_left` aligns duplicate indices before filling missing values
- add unit tests covering duplicate index combinations

## Testing
- pytest tests/unit/test_pandas_utils.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e62cca9044832481b3f3208d13cc6d