### PR TITLE
Fix success rate calculation and CLI behaviours

### DIFF
--- a/library/utils/cli_tools/chunk_io_main.py
+++ b/library/utils/cli_tools/chunk_io_main.py
@@ -15,8 +15,13 @@ from library.cli import (
     create_logger_config,
     path_argument,
 )
-from library.config import Config, ConfigError, ensure_dirs, print_config
-from library.config.loader import DEFAULT_CONFIG_RELATIVE
+from library.config import (
+    Config,
+    ConfigError,
+    DEFAULT_CONFIG_PATH,
+    ensure_dirs,
+    print_config,
+)
 from library.io.paths import default_output_path
 from library.common.log import logger
 

--- a/library/utils/cli_tools/get_activities.py
+++ b/library/utils/cli_tools/get_activities.py
@@ -21,6 +21,9 @@ from library.config import (
 from library.pipelines.activity import get_activities
 
 
+DEFAULT_LIMIT = 25
+
+
 def parse_args(
     argv: Sequence[str] | None = None,
 ) -> tuple[argparse.ArgumentParser, argparse.Namespace, cli.LoggerConfig]:
@@ -59,7 +62,7 @@ def parse_args(
         "--limit",
         type=_limit,
         default=None,
-        help="Maximum number of activity rows to emit",
+        help=f"Maximum number of activity rows to emit (default: {DEFAULT_LIMIT})",
     )
     parser.add_argument(
         "--dry-run",
@@ -85,7 +88,6 @@ def _frame_from_records(records: Iterable[dict[str, object]]) -> pd.DataFrame:
 def _write_output(frame: pd.DataFrame, output_path: Path, *, cfg: Config) -> Path:
     """Persist ``frame`` and accompanying metadata to ``output_path`` atomically."""
 
-    output_path.parent.mkdir(parents=True, exist_ok=True)
     temp_path = output_path.with_name(
         f".{output_path.name}.{uuid4().hex}.tmp"
     )
@@ -114,7 +116,11 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
 
     limit = args.limit
     if limit is None:
-        limit = cfg.activity.limit if cfg.activity.limit is not None else 0
+        limit = (
+            cfg.activity.limit
+            if cfg.activity.limit is not None
+            else DEFAULT_LIMIT
+        )
         if limit < 0:
             logger.error(
                 "config_error",
@@ -138,6 +144,25 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
         setattr(args, "final_out", output_path)
     else:
         output_path = Path(output_candidate)
+
+    parent = output_path.parent
+    if not parent.exists():
+        if cfg.io.exist_ok:
+            parent.mkdir(parents=True, exist_ok=True)
+        else:
+            logger.error(
+                "output_directory_missing",
+                directory=str(parent),
+                output=str(output_path),
+            )
+            return 1
+    elif not parent.is_dir():
+        logger.error(
+            "output_directory_not_directory",
+            directory=str(parent),
+            output=str(output_path),
+        )
+        return 1
 
     if bool(getattr(args, "skip_existing", False)) and output_path.exists() and not bool(
         getattr(args, "force", False)

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -223,11 +223,18 @@ def _build_test_entry(test: dict[str, Any]) -> dict[str, Any]:
 
 
 def _calculate_success_rate(summary: dict[str, int]) -> float:
-    total = summary.get("total", 0) or 0
-    passed = summary.get("passed", 0) or 0
-    if total <= 0:
+    total = int(summary.get("total", 0) or 0)
+    skipped = int(summary.get("skipped", 0) or 0)
+    passed = int(summary.get("passed", 0) or 0)
+    xfailed = int(summary.get("xfailed", 0) or 0)
+
+    executed_total = total - skipped
+    if executed_total <= 0:
         return 1.0
-    return max(0.0, min(1.0, passed / total))
+
+    successes = passed + xfailed
+    ratio = successes / executed_total
+    return max(0.0, min(1.0, ratio))
 
 
 def build_structured_report(raw: dict[str, Any], exit_code: int) -> dict[str, Any]:

--- a/tests/e2e/test_chunk_io_cli.py
+++ b/tests/e2e/test_chunk_io_cli.py
@@ -1,0 +1,85 @@
+"""End-to-end checks for :mod:`library.utils.cli_tools.chunk_io_main`."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import pytest
+
+from types import SimpleNamespace
+
+from library.utils.cli_tools import chunk_io_main
+
+
+@pytest.mark.e2e
+def test_chunk_io_main__copies_csv(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    input_csv = tmp_path / "input.csv"
+    rows = [
+        ["molecule_chembl_id", "name", "smiles"],
+        ["CHEMBL1", "Aspirin", "CC(=O)OC1=CC=CC=C1C(=O)O"],
+        ["CHEMBL2", "Unknown", ""],
+    ]
+    with input_csv.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerows(rows)
+
+    output_csv = tmp_path / "output" / "copy.csv"
+    checkpoint = tmp_path / "state.json"
+
+    monkeypatch.setenv("CHEMBL_DA_BASE_PATH", str(tmp_path / "chembl-data"))
+
+    cfg_stub = SimpleNamespace(
+        io=SimpleNamespace(
+            exist_ok=True,
+            output_dir=tmp_path,
+            cache_dir=tmp_path / "cache",
+            csv_sep=",",
+            csv_encoding="utf-8",
+        )
+    )
+
+    def _cfg_to_dict() -> dict[str, object]:
+        return {
+            "io": {
+                "exist_ok": True,
+                "output_dir": str(tmp_path),
+                "cache_dir": str(tmp_path / "cache"),
+                "csv_sep": ",",
+                "csv_encoding": "utf-8",
+            }
+        }
+
+    cfg_stub.to_dict = _cfg_to_dict  # type: ignore[attr-defined]
+
+    captured: dict[str, object] = {}
+
+    def _fake_apply_config(args, parser, config_path):
+        captured["config_path"] = config_path
+        return cfg_stub
+
+    monkeypatch.setattr(chunk_io_main.cli, "apply_config_overrides", _fake_apply_config)
+
+    exit_code = chunk_io_main.main(
+        [
+            "--input",
+            str(input_csv),
+            "--final-out",
+            str(output_csv),
+            "--checkpoint",
+            str(checkpoint),
+            "--chunk-size",
+            "2",
+        ]
+    )
+
+    assert exit_code == 0
+    assert captured["config_path"] == chunk_io_main.DEFAULT_CONFIG_PATH
+    assert output_csv.exists()
+    assert checkpoint.exists()
+
+    with output_csv.open("r", newline="", encoding="utf-8") as handle:
+        reader = csv.reader(handle)
+        written_rows = list(reader)
+
+    assert written_rows == rows

--- a/tests/unit/scripts/test_get_activities_cli.py
+++ b/tests/unit/scripts/test_get_activities_cli.py
@@ -5,7 +5,6 @@ from types import SimpleNamespace
 
 import pytest
 
-from library.config import Config
 from library.utils.cli_tools import get_activities
 
 
@@ -26,6 +25,35 @@ class _LoggerStub:
 
     def error(self, event: str, **data: object) -> None:  # pragma: no cover - defensive
         self.events.append(("error", event, dict(data)))
+
+    def exception(self, event: str, **data: object) -> None:  # pragma: no cover - defensive
+        self.events.append(("exception", event, dict(data)))
+
+
+def _make_cfg_stub(base: Path, *, limit: int | None = None, exist_ok: bool = True):
+    io_cfg = SimpleNamespace(
+        exist_ok=exist_ok,
+        output_dir=base,
+        cache_dir=base / "cache",
+        csv_sep=",",
+        csv_encoding="utf-8",
+    )
+    cfg_stub = SimpleNamespace(activity=SimpleNamespace(limit=limit), io=io_cfg)
+
+    def _to_dict() -> dict[str, object]:
+        return {
+            "activity": {"limit": limit},
+            "io": {
+                "exist_ok": exist_ok,
+                "output_dir": str(base),
+                "cache_dir": str(base / "cache"),
+                "csv_sep": ",",
+                "csv_encoding": "utf-8",
+            },
+        }
+
+    cfg_stub.to_dict = _to_dict  # type: ignore[attr-defined]
+    return cfg_stub
 
 
 @pytest.mark.unit
@@ -57,6 +85,14 @@ def test_main__limit_forwarded_to_pipeline(
 
     monkeypatch.setattr(get_activities.cli, "prepare_io_paths", _prepare_io_paths)
     monkeypatch.setattr(get_activities.cli, "configure_logger", lambda *_a, **_k: None)
+    cfg_stub = _make_cfg_stub(tmp_path, limit=None)
+
+    monkeypatch.setattr(
+        get_activities.cli,
+        "apply_config_overrides",
+        lambda args, parser, config: cfg_stub,
+    )
+    monkeypatch.setattr(get_activities, "ensure_dirs", lambda _cfg: None)
 
     logger_stub = _LoggerStub()
     monkeypatch.setattr(get_activities, "logger", logger_stub)
@@ -112,6 +148,15 @@ def test_main__dry_run_skips_fetch(
     monkeypatch.setattr(get_activities.cli, "prepare_io_paths", _prepare_io_paths)
     monkeypatch.setattr(get_activities.cli, "configure_logger", lambda *_a, **_k: None)
 
+    cfg_stub = _make_cfg_stub(tmp_path, limit=None)
+
+    monkeypatch.setattr(
+        get_activities.cli,
+        "apply_config_overrides",
+        lambda args, parser, config: cfg_stub,
+    )
+    monkeypatch.setattr(get_activities, "ensure_dirs", lambda _cfg: None)
+
     logger_stub = _LoggerStub()
     monkeypatch.setattr(get_activities, "logger", logger_stub)
 
@@ -135,13 +180,13 @@ def test_main__dry_run_skips_fetch(
 
 @pytest.mark.unit
 def test_main__config_limit_used_when_cli_omitted(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     input_csv = tmp_path / "input.csv"
     input_csv.write_text("id\nCHEMBL1\n", encoding="utf-8")
     output_csv = tmp_path / "output.csv"
 
-    cfg.activity.limit = 4
+    cfg_stub = _make_cfg_stub(tmp_path, limit=4)
 
     observed: dict[str, int] = {}
 
@@ -167,7 +212,7 @@ def test_main__config_limit_used_when_cli_omitted(
     monkeypatch.setattr(
         get_activities.cli,
         "apply_config_overrides",
-        lambda args, parser, config: cfg,
+        lambda args, parser, config: cfg_stub,
     )
     monkeypatch.setattr(get_activities, "ensure_dirs", lambda _cfg: None)
 
@@ -201,10 +246,12 @@ def test_parse_args__invalid_limit_error_message(capsys: pytest.CaptureFixture[s
 
 @pytest.mark.unit
 def test_run__skip_existing_respects_flag(
-    tmp_path: Path, cfg: Config, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     output_csv = tmp_path / "activities.csv"
     output_csv.write_text("activity_id\nOLD\n", encoding="utf-8")
+
+    cfg = _make_cfg_stub(tmp_path)
 
     args = SimpleNamespace(
         limit=1,
@@ -241,10 +288,12 @@ def test_run__skip_existing_respects_flag(
 
 @pytest.mark.unit
 def test_run__force_overrides_skip_existing(
-    tmp_path: Path, cfg: Config, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     output_csv = tmp_path / "activities.csv"
     output_csv.write_text("activity_id\nOLD\n", encoding="utf-8")
+
+    cfg = _make_cfg_stub(tmp_path)
 
     args = SimpleNamespace(
         limit=2,
@@ -288,3 +337,109 @@ def test_parse_args__only_expected_options_present() -> None:
 
     assert "chunk_size" not in vars(args)
     assert "column" not in vars(args)
+
+
+@pytest.mark.unit
+def test_run__default_limit_used_when_config_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = _make_cfg_stub(tmp_path, limit=None)
+
+    args = SimpleNamespace(
+        limit=None,
+        dry_run=False,
+        skip_existing=False,
+        force=False,
+        output_csv=tmp_path / "activities.csv",
+        input_csv=tmp_path / "input.csv",
+    )
+
+    observed: dict[str, int] = {}
+
+    def _fake_get(limit: int) -> list[dict[str, int]]:
+        observed["limit"] = limit
+        return [{"activity_id": idx} for idx in range(limit)]
+
+    monkeypatch.setattr(get_activities, "get_activities", _fake_get)
+    monkeypatch.setattr(get_activities, "_write_output", lambda *_a, **_k: args.output_csv)
+
+    logger_stub = _LoggerStub()
+    monkeypatch.setattr(get_activities, "logger", logger_stub)
+
+    exit_code = get_activities.run(cfg, args)
+
+    assert exit_code == 0
+    assert observed["limit"] == get_activities.DEFAULT_LIMIT
+
+
+@pytest.mark.unit
+def test_run__writes_output_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = _make_cfg_stub(tmp_path, exist_ok=True)
+
+    output_csv = tmp_path / "nested" / "activities.csv"
+    args = SimpleNamespace(
+        limit=2,
+        dry_run=False,
+        skip_existing=False,
+        force=False,
+        output_csv=output_csv,
+        input_csv=tmp_path / "input.csv",
+    )
+
+    def _fake_get(limit: int) -> list[dict[str, int]]:
+        return [{"activity_id": idx + 1} for idx in range(limit)]
+
+    monkeypatch.setattr(get_activities, "get_activities", _fake_get)
+
+    logger_stub = _LoggerStub()
+    monkeypatch.setattr(get_activities, "logger", logger_stub)
+
+    exit_code = get_activities.run(cfg, args)
+
+    assert exit_code == 0
+    assert output_csv.exists()
+    content = output_csv.read_text(encoding="utf-8").splitlines()
+    assert content == ["activity_id", "1", "2"]
+    meta_path = Path(f"{output_csv}.meta.yaml")
+    assert meta_path.exists()
+    assert any(event[1] == "generated" for event in logger_stub.events)
+
+
+@pytest.mark.unit
+def test_run__fails_when_directory_missing_and_exist_ok_false(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = _make_cfg_stub(tmp_path, exist_ok=False)
+
+    output_dir = tmp_path / "missing" / "deeper"
+    output_csv = output_dir / "activities.csv"
+
+    args = SimpleNamespace(
+        limit=1,
+        dry_run=False,
+        skip_existing=False,
+        force=False,
+        output_csv=output_csv,
+        input_csv=tmp_path / "input.csv",
+    )
+
+    monkeypatch.setattr(
+        get_activities,
+        "get_activities",
+        lambda *_a, **_k: pytest.fail("get_activities should not be called"),
+    )
+
+    logger_stub = _LoggerStub()
+    monkeypatch.setattr(get_activities, "logger", logger_stub)
+
+    exit_code = get_activities.run(cfg, args)
+
+    assert exit_code == 1
+    assert not output_dir.exists()
+    assert (
+        "error",
+        "output_directory_missing",
+        {"directory": str(output_dir), "output": str(output_csv)},
+    ) in logger_stub.events

--- a/tests/unit/scripts/test_run_tests_script.py
+++ b/tests/unit/scripts/test_run_tests_script.py
@@ -219,6 +219,41 @@ def test_build_summary_markdown__renders_error_messages_from_json() -> None:
     assert "line 1" in summary_md and "line 2" in summary_md
 
 
+@pytest.mark.unit
+def test_calculate_success_rate__counts_passed_and_xfailed() -> None:
+    summary = {
+        "total": 6,
+        "passed": 3,
+        "failed": 1,
+        "skipped": 1,
+        "xfailed": 1,
+        "xpassed": 0,
+        "error": 0,
+    }
+
+    success_rate = run_tests._calculate_success_rate(summary)
+
+    # Executed tests exclude the skipped item -> 5 executed, 4 successes
+    assert success_rate == pytest.approx(4 / 5)
+
+
+@pytest.mark.unit
+def test_calculate_success_rate__all_skipped_return_unity() -> None:
+    summary = {
+        "total": 3,
+        "passed": 0,
+        "failed": 0,
+        "skipped": 3,
+        "xfailed": 0,
+        "xpassed": 0,
+        "error": 0,
+    }
+
+    success_rate = run_tests._calculate_success_rate(summary)
+
+    assert success_rate == pytest.approx(1.0)
+
+
 
 @pytest.mark.unit
 def test_main__returns_exit_code_one_when_quality_gate_fails(


### PR DESCRIPTION
## Summary
- adjust the run_tests success-rate computation to ignore skipped tests, count xfails and cover it with dedicated unit checks
- update the get_activities CLI to default to a 25-row limit, honour cfg.io.exist_ok when preparing outputs, and expand the test suite accordingly
- ensure the chunk-io CLI resolves the default config path correctly and exercise it with a lightweight e2e scenario

## Testing
- pytest tests/unit/scripts/test_run_tests_script.py tests/unit/scripts/test_get_activities_cli.py tests/e2e/test_chunk_io_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68e656ec746c83248539e9249b3c055d