### PR TITLE
Add postprocessing CLI entrypoints and integration tests

### DIFF
--- a/README_postprocess.md
+++ b/README_postprocess.md
@@ -64,6 +64,31 @@ The domain YAML files ship representative defaults that downstream tooling can r
 | Assays | `utf-8` | `,` | `uppercase_categories: true`, `strip_whitespace: true`, `normalize_identifiers: true` |
 | Targets | `utf-8` | `,` | `normalize_taxonomy: true`, `fill_missing_identifiers: true`, `sort_by: ['target_chembl_id']` |
 | Documents | `utf-8` | `,` | `trim_whitespace: true`, `normalise_unicode: true`, `ensure_unique_ids: true` |
+| Test items | `utf-8` | `,` | `uppercase_identifiers: true`, `coerce_booleans: true`, `fill_missing_columns: true` |
+
+## CLI entry points
+
+The postprocessing stages ship dedicated CLI wrappers under `scripts/make_<table>_postprocessing.py`. Each command wires argument
+parsing, logging configuration and deterministic CSV export around the domain pipeline.
+
+Shared interface:
+
+- `--input`: path to the raw CSV exported by the extractor stage.
+- `--output`: destination for the enriched CSV; parent directories are created automatically.
+- `--config`: optional override YAML (defaults to `config/pipeline/<table>.yaml`, e.g. `config/pipeline/testitems.yaml`).
+- `--log-level`: overrides the YAML/default log verbosity.
+
+By default logs are written to `logs/make_<table>_postprocessing_<YYYYMMDD>.log`. Override the directory by exporting
+`CHEMBL_POSTPROCESS_LOG_DIR`. Each run also emits `<table>.postprocess.report.json` alongside the output CSV with the pipeline
+metrics collected via `collect_postprocess_metrics`.
+
+Example invocation:
+
+```bash
+python -m scripts.make_activity_postprocessing --input data/raw/activities.csv --output data/out/activities.csv
+```
+
+The same pattern applies to assays, documents, targets and test items.
 
 Each steps module imports its matching configuration, exposing `PIPELINE_CONFIG` and constructing `PIPELINE_STEPS` directly from the YAML definition so future additions require no code edits. 【F:library/postprocess/assays/steps.py†L1-L76】【F:library/postprocess/documents/steps.py†L1-L82】【F:library/postprocess/targets/steps.py†L1-L80】
 

--- a/config/pipeline/testitems.yaml
+++ b/config/pipeline/testitems.yaml
@@ -1,0 +1,27 @@
+# Default test item post-processing pipeline configuration.
+pipeline_version: "${CHEMBL_TESTITEM_PIPELINE_VERSION:-auto}"
+enabled_steps:
+  - name: normalize_testitem_records
+    callable: "library.postprocess.testitem.steps:normalize_testitem_records"
+    description: "Normalise identifiers, canonical names and boolean flags."
+    params:
+      uppercase_identifiers: true
+      coerce_booleans: true
+  - name: enrich_testitem_annotations
+    callable: "library.postprocess.testitem.steps:enrich_testitem_annotations"
+    description: "Fill optional annotation columns with deterministic defaults."
+  - name: finalize_testitem_records
+    callable: "library.postprocess.testitem.steps:finalize_testitem_records"
+    description: "Validate schema expectations and stabilise column ordering."
+    params:
+      enforce_schema: true
+params:
+  defaults:
+    pipeline_version: "${CHEMBL_TESTITEM_PIPELINE_VERSION:-auto}"
+    log_level: "${POSTPROCESS_LOG_LEVEL:-INFO}"
+  io:
+    encoding: "${POSTPROCESS_DEFAULT_ENCODING:-utf-8}"
+    csv_sep: "${POSTPROCESS_DEFAULT_CSV_SEPARATOR:-,}"
+  normalization:
+    uppercase_identifiers: true
+    coerce_booleans: true

--- a/library/postprocess/__init__.py
+++ b/library/postprocess/__init__.py
@@ -1,5 +1,12 @@
 """Postprocessing utilities for curated ChEMBL datasets."""
 
-from . import activities, assays, common, documents, targets
+from . import activities, assays, common, documents, targets, testitem
 
-__all__ = ["activities", "assays", "common", "documents", "targets"]
+__all__ = [
+    "activities",
+    "assays",
+    "common",
+    "documents",
+    "targets",
+    "testitem",
+]

--- a/library/postprocess/testitem/__init__.py
+++ b/library/postprocess/testitem/__init__.py
@@ -1,0 +1,24 @@
+"""Postprocessing helpers for the test item table."""
+
+from .schema import BOOLEAN_COLUMNS, TESTITEM_SCHEMA, validate_testitems
+from .steps import (
+    PIPELINE_CONFIG,
+    PIPELINE_STEPS,
+    enrich_testitem_annotations,
+    finalize_testitem_records,
+    normalize_testitem_records,
+    run_testitem_pipeline,
+)
+
+__all__ = [
+    "BOOLEAN_COLUMNS",
+    "PIPELINE_CONFIG",
+    "PIPELINE_STEPS",
+    "TESTITEM_SCHEMA",
+    "enrich_testitem_annotations",
+    "finalize_testitem_records",
+    "normalize_testitem_records",
+    "run_testitem_pipeline",
+    "validate_testitems",
+]
+

--- a/library/postprocess/testitem/schema.py
+++ b/library/postprocess/testitem/schema.py
@@ -1,0 +1,118 @@
+"""Schema specification for test item postprocessing outputs."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import pandas as pd
+
+from library.postprocess.common import DataFrameSchema, validate_schema
+
+
+BOOLEAN_COLUMNS: Sequence[str] = (
+    "natural_product",
+    "prodrug",
+    "polymer_flag",
+    "oral",
+    "parenteral",
+    "topical",
+)
+
+
+TESTITEM_SCHEMA = DataFrameSchema(
+    required_columns=("molecule_chembl_id",),
+    optional_columns=(
+        "parent_molecule_chembl_id",
+        "salt_chembl_id",
+        "natural_product",
+        "prodrug",
+        "polymer_flag",
+        "black_box_warning",
+        "first_approval",
+        "max_phase",
+        "canonical_smiles",
+        "standard_inchi",
+        "standard_inchi_key",
+        "molecule_type",
+        "oral",
+        "parenteral",
+        "pref_name",
+        "pubchem_canonical_smiles",
+        "pubchem_cid",
+        "pubchem_inchi",
+        "pubchem_inchikey",
+        "pubchem_isomeric_smiles",
+        "pubchem_iupac_name",
+        "pubchem_molecular_formula",
+        "structure_type",
+        "topical",
+        "pipeline_version",
+        "timestamp_utc",
+    ),
+    dtypes={
+        "molecule_chembl_id": "string",
+        "parent_molecule_chembl_id": "string",
+        "salt_chembl_id": "string",
+        "natural_product": pd.BooleanDtype(),
+        "prodrug": pd.BooleanDtype(),
+        "polymer_flag": pd.BooleanDtype(),
+        "canonical_smiles": "string",
+        "standard_inchi": "string",
+        "standard_inchi_key": "string",
+        "molecule_type": "string",
+        "oral": pd.BooleanDtype(),
+        "parenteral": pd.BooleanDtype(),
+        "pref_name": "string",
+        "pubchem_canonical_smiles": "string",
+        "pubchem_cid": object,
+        "pubchem_inchi": "string",
+        "pubchem_inchikey": "string",
+        "pubchem_isomeric_smiles": "string",
+        "pubchem_iupac_name": "string",
+        "pubchem_molecular_formula": "string",
+        "structure_type": "string",
+        "topical": pd.BooleanDtype(),
+        "pipeline_version": "string",
+        "timestamp_utc": "string",
+    },
+    sort_by=("molecule_chembl_id",),
+    column_order=(
+        "molecule_chembl_id",
+        "parent_molecule_chembl_id",
+        "salt_chembl_id",
+        "pref_name",
+        "molecule_type",
+        "structure_type",
+        "max_phase",
+        "natural_product",
+        "prodrug",
+        "polymer_flag",
+        "oral",
+        "parenteral",
+        "topical",
+        "black_box_warning",
+        "first_approval",
+        "canonical_smiles",
+        "standard_inchi",
+        "standard_inchi_key",
+        "pubchem_cid",
+        "pubchem_canonical_smiles",
+        "pubchem_isomeric_smiles",
+        "pubchem_inchi",
+        "pubchem_inchikey",
+        "pubchem_iupac_name",
+        "pubchem_molecular_formula",
+        "timestamp_utc",
+        "pipeline_version",
+    ),
+)
+
+
+def validate_testitems(df: pd.DataFrame, *, context: str = "testitems") -> pd.DataFrame:
+    """Validate ``df`` using :data:`TESTITEM_SCHEMA`."""
+
+    return validate_schema(df, TESTITEM_SCHEMA, context=context)
+
+
+__all__ = ["BOOLEAN_COLUMNS", "TESTITEM_SCHEMA", "validate_testitems"]
+

--- a/library/postprocess/testitem/steps.py
+++ b/library/postprocess/testitem/steps.py
@@ -1,0 +1,230 @@
+"""Transformation steps for the test item postprocessing pipeline."""
+
+from __future__ import annotations
+
+from typing import Mapping, Sequence
+
+import pandas as pd
+
+from library.postprocess.common import run_steps
+from library.postprocess.common.logging import PipelineRunMetrics
+from library.postprocess.common.config import (
+    load_pipeline_config,
+    normalize_pipeline_version,
+)
+from library.pipelines.common.metadata import get_pipeline_version
+
+from .schema import BOOLEAN_COLUMNS, TESTITEM_SCHEMA, validate_testitems
+
+
+TRUE_MARKERS = {"true", "1", "yes", "y", "t"}
+FALSE_MARKERS = {"false", "0", "no", "n", "f"}
+
+
+def _normalise_identifier(series: pd.Series) -> pd.Series:
+    return series.astype("string").str.strip().str.upper()
+
+
+def _normalise_string(series: pd.Series) -> pd.Series:
+    return series.astype("string").str.strip()
+
+
+def _coerce_boolean(series: pd.Series) -> pd.Series:
+    def _convert(value: object) -> object:
+        if value is None or (isinstance(value, float) and pd.isna(value)):
+            return pd.NA
+        if isinstance(value, bool):
+            return value
+        text = str(value).strip().lower()
+        if not text:
+            return pd.NA
+        if text in TRUE_MARKERS:
+            return True
+        if text in FALSE_MARKERS:
+            return False
+        return pd.NA
+
+    coerced = series.map(_convert)
+    return pd.Series(pd.array(coerced, dtype=pd.BooleanDtype()), index=series.index)
+
+
+def normalize_testitem_records(
+    df: pd.DataFrame,
+    *,
+    uppercase_identifiers: bool = True,
+    coerce_booleans: bool = True,
+    string_columns: Sequence[str] | None = None,
+) -> pd.DataFrame:
+    """Normalise identifier casing and canonical string columns."""
+
+    normalized = df.copy(deep=True)
+
+    identifier_columns = (
+        "molecule_chembl_id",
+        "parent_molecule_chembl_id",
+        "salt_chembl_id",
+    )
+    if uppercase_identifiers:
+        for column in identifier_columns:
+            if column in normalized.columns:
+                normalized[column] = _normalise_identifier(normalized[column])
+    else:
+        for column in identifier_columns:
+            if column in normalized.columns:
+                normalized[column] = normalized[column].astype("string").str.strip()
+
+    default_string_columns = (
+        "pref_name",
+        "molecule_type",
+        "structure_type",
+        "max_phase",
+        "canonical_smiles",
+        "standard_inchi",
+        "standard_inchi_key",
+        "pubchem_canonical_smiles",
+        "pubchem_isomeric_smiles",
+        "pubchem_inchi",
+        "pubchem_inchikey",
+        "pubchem_iupac_name",
+        "pubchem_molecular_formula",
+        "black_box_warning",
+        "first_approval",
+        "timestamp_utc",
+    )
+
+    target_columns = string_columns or default_string_columns
+    for column in target_columns:
+        if column in normalized.columns:
+            normalized[column] = _normalise_string(normalized[column])
+
+    if "pubchem_cid" in normalized.columns:
+        normalized["pubchem_cid"] = normalized["pubchem_cid"].astype(object)
+
+    if coerce_booleans:
+        for column in BOOLEAN_COLUMNS:
+            if column in normalized.columns:
+                normalized[column] = _coerce_boolean(normalized[column])
+
+    return normalized
+
+
+def enrich_testitem_annotations(
+    df: pd.DataFrame,
+    *,
+    fill_missing_columns: bool = True,
+) -> pd.DataFrame:
+    """Ensure optional annotation columns exist with deterministic defaults."""
+
+    enriched = df.copy(deep=True)
+    if not fill_missing_columns:
+        return enriched
+
+    row_count = len(enriched.index)
+    for column in TESTITEM_SCHEMA.optional_columns:
+        if column in enriched.columns:
+            continue
+        dtype = TESTITEM_SCHEMA.dtypes.get(column)
+        if isinstance(dtype, pd.BooleanDtype):
+            enriched[column] = pd.Series(
+                pd.array([pd.NA] * row_count, dtype=dtype), index=enriched.index
+            )
+        elif dtype is object:
+            enriched[column] = pd.Series([pd.NA] * row_count, index=enriched.index, dtype="object")
+        else:
+            target_dtype = "string" if dtype is None else dtype
+            enriched[column] = pd.Series(pd.array([pd.NA] * row_count, dtype=target_dtype), index=enriched.index)
+    return enriched
+
+
+def _ensure_column_types(df: pd.DataFrame) -> pd.DataFrame:
+    coerced = df.copy(deep=True)
+    for column, dtype in TESTITEM_SCHEMA.dtypes.items():
+        if column not in coerced.columns:
+            continue
+        try:
+            coerced[column] = coerced[column].astype(dtype)
+        except TypeError:
+            if dtype is object:
+                coerced[column] = coerced[column].astype("object")
+            else:
+                coerced[column] = coerced[column].astype("string")
+    return coerced
+
+
+def finalize_testitem_records(
+    df: pd.DataFrame,
+    *,
+    enforce_schema: bool = True,
+    pipeline_version: str | None = None,
+    sort_by: Sequence[str] | None = None,
+) -> pd.DataFrame:
+    """Validate and reorder the DataFrame according to :data:`TESTITEM_SCHEMA`."""
+
+    prepared = df.copy(deep=True)
+
+    if pipeline_version:
+        prepared["pipeline_version"] = prepared.get(
+            "pipeline_version",
+            pd.Series(pd.array([pipeline_version] * len(prepared.index), dtype="string"), index=prepared.index),
+        )
+        prepared["pipeline_version"] = prepared["pipeline_version"].astype("string").fillna(str(pipeline_version))
+
+    prepared = _ensure_column_types(prepared)
+
+    if enforce_schema:
+        validated = validate_testitems(prepared, context="testitems_finalization")
+    else:
+        validated = prepared
+
+    ordering = sort_by or TESTITEM_SCHEMA.sort_by or ()
+    if ordering:
+        sort_columns = [column for column in ordering if column in validated.columns]
+        if sort_columns:
+            validated = validated.sort_values(sort_columns, kind="mergesort").reset_index(drop=True)
+
+    return validated
+
+
+PIPELINE_CONFIG = load_pipeline_config("testitems")
+PIPELINE_STEPS = PIPELINE_CONFIG.step_definitions()
+
+
+def _resolve_pipeline_version(override: str | None) -> str:
+    candidate = normalize_pipeline_version(override)
+    if candidate is not None:
+        return candidate
+
+    config_candidate = normalize_pipeline_version(PIPELINE_CONFIG.pipeline_version)
+    if config_candidate is not None:
+        return config_candidate
+
+    return get_pipeline_version()
+
+
+def run_testitem_pipeline(
+    df: pd.DataFrame,
+    *,
+    pipeline_version: str | None = None,
+    logger=None,
+) -> tuple[pd.DataFrame, PipelineRunMetrics]:
+    """Execute the test item postprocessing pipeline and return metrics."""
+
+    resolved_version = _resolve_pipeline_version(pipeline_version)
+    return run_steps(
+        df,
+        PIPELINE_STEPS,
+        post_schema=TESTITEM_SCHEMA,
+        pipeline_version=resolved_version,
+        logger=logger,
+    )
+
+
+__all__ = [
+    "PIPELINE_CONFIG",
+    "PIPELINE_STEPS",
+    "enrich_testitem_annotations",
+    "finalize_testitem_records",
+    "normalize_testitem_records",
+    "run_testitem_pipeline",
+]
+

--- a/scripts/_postprocess_common.py
+++ b/scripts/_postprocess_common.py
@@ -1,0 +1,276 @@
+"""Shared helpers for post-processing CLI entry points."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Callable, Mapping, Sequence
+
+import pandas as pd
+
+from library import io
+from library.common.csv_utils import write_csv_chunks_deterministic
+from library.postprocess.common.config import PipelineConfig, load_pipeline_config
+from library.postprocess.common.logging import PipelineRunMetrics
+from library.postprocess.common.schema import DataFrameSchema
+from library.postprocess.common.types import SchemaValidationError, StepError
+from library.postprocess.common.utils import collect_postprocess_metrics
+
+
+LOG_DIR_ENV = "CHEMBL_POSTPROCESS_LOG_DIR"
+DEFAULT_LOG_DIR = Path("logs")
+
+
+@dataclass(slots=True)
+class CsvRuntimeConfig:
+    """Runtime configuration for CSV I/O operations."""
+
+    sep: str
+    encoding: str
+    chunksize: int = 10000
+
+
+def event_prefix(table: str) -> str:
+    """Return the structured logging prefix for ``table``."""
+
+    return f"{table}_postprocess"
+
+
+def get_pipeline_config(table: str, config_path: Path | None) -> PipelineConfig:
+    """Load the pipeline configuration for ``table``."""
+
+    return load_pipeline_config(table, config_path)
+
+
+def get_csv_runtime_config(config: PipelineConfig) -> CsvRuntimeConfig:
+    """Derive CSV runtime parameters from ``config``."""
+
+    params = dict(config.params or {})
+    io_params = dict(params.get("io", {}))
+    sep = str(io_params.get("csv_sep", ","))
+    encoding = str(io_params.get("encoding", "utf-8"))
+    chunksize = int(io_params.get("chunksize", 10000))
+    return CsvRuntimeConfig(sep=sep, encoding=encoding, chunksize=chunksize)
+
+
+def get_default_log_level(config: PipelineConfig) -> str:
+    """Return the default log level declared in ``config``."""
+
+    params = dict(config.params or {})
+    defaults = params.get("defaults", {}) or {}
+    level = defaults.get("log_level", "INFO")
+    return str(level).upper()
+
+
+def ensure_pipeline_version_column(
+    df: pd.DataFrame, pipeline_version: str | None
+) -> pd.DataFrame:
+    """Ensure ``pipeline_version`` is represented as a string column."""
+
+    if not pipeline_version:
+        return df
+
+    prepared = df.copy(deep=True)
+    version = str(pipeline_version)
+    if "pipeline_version" in prepared.columns:
+        series = prepared["pipeline_version"].astype("string")
+        prepared["pipeline_version"] = series.fillna(version)
+    else:
+        prepared["pipeline_version"] = pd.Series(
+            pd.array([version] * len(prepared.index), dtype="string"),
+            index=prepared.index,
+        )
+    return prepared
+
+
+def load_input_frame(
+    table: str,
+    path: Path,
+    csv_cfg: CsvRuntimeConfig,
+    *,
+    logger,
+) -> pd.DataFrame:
+    """Load the raw output frame for ``table`` from ``path``."""
+
+    prefix = event_prefix(table)
+    logger.info(
+        f"{prefix}_load_start",
+        input=str(path),
+        encoding=csv_cfg.encoding,
+        separator=csv_cfg.sep,
+    )
+    namespace = SimpleNamespace(csv_sep=csv_cfg.sep, csv_encoding=csv_cfg.encoding)
+    frame = io.read_csv(path, cfg=namespace)
+    rows, cols = frame.shape
+    logger.info(
+        f"{prefix}_load_done",
+        rows=int(rows),
+        columns=int(cols),
+    )
+    return frame
+
+
+def run_postprocess_steps(
+    table: str,
+    df: pd.DataFrame,
+    runner: Callable[..., tuple[pd.DataFrame, PipelineRunMetrics]],
+    pipeline_version: str | None,
+    *,
+    logger,
+) -> tuple[pd.DataFrame, PipelineRunMetrics]:
+    """Execute postprocessing ``runner`` for ``table``."""
+
+    prefix = event_prefix(table)
+    logger.info(
+        f"{prefix}_pipeline_start",
+        rows=int(df.shape[0]),
+        columns=int(df.shape[1]),
+        pipeline_version=pipeline_version,
+    )
+    processed, metrics = runner(
+        df,
+        pipeline_version=pipeline_version,
+        logger=logger,
+    )
+    summary = metrics.summary()
+    logger.info(f"{prefix}_pipeline_done", **summary)
+    return processed, metrics
+
+
+def validate_postprocess_frame(
+    table: str,
+    df: pd.DataFrame,
+    validator: Callable[..., pd.DataFrame],
+    schema: DataFrameSchema,
+    pipeline_version: str | None,
+    *,
+    logger,
+) -> pd.DataFrame:
+    """Validate ``df`` using ``validator`` aligned with ``schema``."""
+
+    prefix = event_prefix(table)
+    logger.info(
+        f"{prefix}_validate_start",
+        schema=schema.__class__.__name__,
+    )
+    prepared = ensure_pipeline_version_column(df, pipeline_version)
+    validated = validator(prepared, context=f"{table}_postprocess")
+    logger.info(
+        f"{prefix}_validate_done",
+        rows=int(validated.shape[0]),
+        columns=int(validated.shape[1]),
+    )
+    return validated
+
+
+def _resolve_key_columns(schema: DataFrameSchema, df: pd.DataFrame) -> Sequence[str]:
+    candidates: Sequence[str] = schema.sort_by or schema.required_columns or ()
+    selected = [column for column in candidates if column in df.columns]
+    if not selected:
+        remaining = [column for column in df.columns if column]
+        if not remaining:
+            raise SchemaValidationError(
+                "export",
+                "no columns available to determine deterministic ordering",
+            )
+        selected = [remaining[0]]
+    return tuple(selected)
+
+
+def export_postprocess_frame(
+    table: str,
+    df: pd.DataFrame,
+    output_path: Path,
+    csv_cfg: CsvRuntimeConfig,
+    schema: DataFrameSchema,
+    *,
+    logger,
+) -> Path:
+    """Persist ``df`` deterministically to ``output_path``."""
+
+    prefix = event_prefix(table)
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    logger.info(
+        f"{prefix}_export_start",
+        output=str(output_path),
+        rows=int(df.shape[0]),
+        columns=int(df.shape[1]),
+        encoding=csv_cfg.encoding,
+        separator=csv_cfg.sep,
+    )
+
+    key_columns = _resolve_key_columns(schema, df)
+    column_order: Sequence[str] | None
+    if schema.column_order:
+        column_order = tuple(col for col in schema.column_order if col in df.columns)
+    else:
+        column_order = tuple(df.columns)
+
+    write_csv_chunks_deterministic(
+        (df,),
+        output_path,
+        col_order=column_order,
+        key_cols=key_columns,
+        sep=csv_cfg.sep,
+        encoding=csv_cfg.encoding,
+        chunksize=csv_cfg.chunksize,
+    )
+
+    logger.info(f"{prefix}_export_done", output=str(output_path))
+    return output_path
+
+
+def generate_metrics_report(
+    table: str,
+    output_path: Path,
+    csv_cfg: CsvRuntimeConfig,
+    runner: Callable[..., tuple[pd.DataFrame, PipelineRunMetrics]],
+    *,
+    pipeline_version: str | None,
+    extras: Mapping[str, Any] | None,
+    logger,
+) -> tuple[PipelineRunMetrics | None, Path | None]:
+    """Create a structured metrics report for ``table``."""
+
+    prefix = event_prefix(table)
+    metrics, report_path = collect_postprocess_metrics(
+        table=table,
+        output_path=output_path,
+        csv_sep=csv_cfg.sep,
+        csv_encoding=csv_cfg.encoding,
+        output_dir=output_path.parent,
+        runner=runner,
+        logger=logger,
+        pipeline_version=pipeline_version,
+        report_extras=extras or {},
+    )
+    if metrics is not None and report_path is not None:
+        logger.info(
+            f"{prefix}_report_written",
+            report=str(report_path),
+            rows=metrics.output_rows,
+            columns=metrics.output_columns,
+        )
+    else:
+        logger.info(f"{prefix}_report_skipped", output=str(output_path))
+    return metrics, report_path
+
+
+__all__ = [
+    "CsvRuntimeConfig",
+    "DEFAULT_LOG_DIR",
+    "LOG_DIR_ENV",
+    "ensure_pipeline_version_column",
+    "event_prefix",
+    "export_postprocess_frame",
+    "generate_metrics_report",
+    "get_csv_runtime_config",
+    "get_default_log_level",
+    "get_pipeline_config",
+    "load_input_frame",
+    "run_postprocess_steps",
+    "validate_postprocess_frame",
+]
+

--- a/scripts/make_activity_postprocessing.py
+++ b/scripts/make_activity_postprocessing.py
@@ -1,0 +1,233 @@
+"""Command line interface for postprocessing activity exports."""
+
+from __future__ import annotations
+
+if __package__ in {None, ""}:
+    from _bootstrap import bootstrap_cli
+else:  # pragma: no cover - executed when imported as a package module
+    from ._bootstrap import bootstrap_cli
+
+bootstrap_cli(__package__, __file__)
+del bootstrap_cli
+
+import argparse
+import os
+from pathlib import Path
+from typing import Sequence
+
+import pandas as pd
+
+from library import io  # noqa: F401 - imported for CLI parity with existing scripts
+from library.cli import configure_logger, create_logger_config
+from library.cli.logging import setup_cli_logging
+from library.cli.parser import path_argument
+from library.common.log import logger
+from library.postprocess.activities.schema import ACTIVITY_SCHEMA, validate_activities
+from library.postprocess.activities.steps import run_activity_pipeline
+from library.postprocess.common.logging import PipelineRunMetrics
+from library.postprocess.common.types import SchemaValidationError, StepError
+
+from ._postprocess_common import (
+    CsvRuntimeConfig,
+    DEFAULT_LOG_DIR,
+    LOG_DIR_ENV,
+    export_postprocess_frame,
+    generate_metrics_report,
+    get_csv_runtime_config,
+    get_default_log_level,
+    get_pipeline_config,
+    load_input_frame,
+    run_postprocess_steps,
+    validate_postprocess_frame,
+)
+
+
+TABLE_NAME = "activities"
+PROGRAM_NAME = Path(__file__).with_suffix("").name
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create the command line parser for the activity postprocessor."""
+
+    parser = argparse.ArgumentParser(
+        description="Run the activity postprocessing pipeline on a CSV export.",
+    )
+    parser.add_argument(
+        "--input",
+        dest="input",
+        type=path_argument,
+        required=True,
+        help="Input CSV file containing raw activity records.",
+    )
+    parser.add_argument(
+        "--output",
+        dest="output",
+        type=path_argument,
+        required=True,
+        help="Destination CSV file for the postprocessed activities.",
+    )
+    parser.add_argument(
+        "--config",
+        dest="config",
+        type=path_argument,
+        default=None,
+        help="Optional YAML configuration overriding the default pipeline definition.",
+    )
+    parser.add_argument(
+        "--log-level",
+        dest="log_level",
+        default=None,
+        help="Logging verbosity (defaults to the pipeline configuration).",
+    )
+    return parser
+
+
+def load_output_data(path: Path, csv_cfg: CsvRuntimeConfig) -> pd.DataFrame:
+    """Load the raw activity output frame."""
+
+    return load_input_frame(TABLE_NAME, path, csv_cfg, logger=logger)
+
+
+def apply_postprocessing_steps(
+    df: pd.DataFrame,
+    *,
+    pipeline_version: str | None,
+) -> tuple[pd.DataFrame, PipelineRunMetrics]:
+    """Execute the configured activity postprocessing pipeline."""
+
+    return run_postprocess_steps(
+        TABLE_NAME,
+        df,
+        run_activity_pipeline,
+        pipeline_version,
+        logger=logger,
+    )
+
+
+def validate_output_schema(
+    df: pd.DataFrame,
+    *,
+    pipeline_version: str | None,
+) -> pd.DataFrame:
+    """Validate and reorder the DataFrame according to the activity schema."""
+
+    return validate_postprocess_frame(
+        TABLE_NAME,
+        df,
+        validate_activities,
+        ACTIVITY_SCHEMA,
+        pipeline_version,
+        logger=logger,
+    )
+
+
+def save_output_data(
+    df: pd.DataFrame,
+    output_path: Path,
+    csv_cfg: CsvRuntimeConfig,
+) -> Path:
+    """Persist ``df`` deterministically to ``output_path``."""
+
+    return export_postprocess_frame(
+        TABLE_NAME,
+        df,
+        output_path,
+        csv_cfg,
+        ACTIVITY_SCHEMA,
+        logger=logger,
+    )
+
+
+def run(args: argparse.Namespace) -> int:
+    """Execute the activity postprocessing pipeline using ``args``."""
+
+    pipeline_config = getattr(args, "_pipeline_config", None)
+    if pipeline_config is None:
+        pipeline_config = get_pipeline_config(TABLE_NAME, getattr(args, "config", None))
+    csv_cfg = getattr(args, "_csv_runtime_config", None)
+    if csv_cfg is None:
+        csv_cfg = get_csv_runtime_config(pipeline_config)
+
+    input_path = Path(args.input)
+    output_path = Path(args.output)
+    event_prefix = f"{TABLE_NAME}_postprocess"
+
+    if not input_path.exists():
+        logger.error(f"{event_prefix}_input_missing", input=str(input_path))
+        return 1
+
+    metrics: PipelineRunMetrics | None = None
+
+    try:
+        frame = load_output_data(input_path, csv_cfg)
+        processed, metrics = apply_postprocessing_steps(
+            frame,
+            pipeline_version=pipeline_config.pipeline_version,
+        )
+        validated = validate_output_schema(
+            processed,
+            pipeline_version=metrics.pipeline_version,
+        )
+        save_output_data(validated, output_path, csv_cfg)
+    except (SchemaValidationError, StepError) as exc:
+        logger.exception(f"{event_prefix}_failed", exc=exc)
+        return 1
+    except Exception as exc:  # pragma: no cover - defensive guard
+        logger.exception(f"{event_prefix}_unexpected_error", exc=exc)
+        return 1
+
+    if metrics is not None:
+        summary = metrics.summary()
+        summary["output"] = str(output_path)
+        logger.info(f"{event_prefix}_summary", **summary)
+
+    extras = {"input": str(input_path), "output": str(output_path)}
+    generate_metrics_report(
+        TABLE_NAME,
+        output_path,
+        csv_cfg,
+        run_activity_pipeline,
+        pipeline_version=metrics.pipeline_version if metrics else None,
+        extras=extras,
+        logger=logger,
+    )
+
+    logger.info(
+        f"{event_prefix}_done",
+        output=str(output_path),
+        rows=int(validated.shape[0]),
+        columns=int(validated.shape[1]),
+    )
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point wiring argument parsing and logging configuration."""
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    pipeline_config = get_pipeline_config(TABLE_NAME, getattr(args, "config", None))
+    csv_cfg = get_csv_runtime_config(pipeline_config)
+    log_level = (args.log_level or get_default_log_level(pipeline_config)).upper()
+    log_cfg = create_logger_config(log_level)
+
+    log_dir_value = os.environ.get(LOG_DIR_ENV)
+    if log_dir_value:
+        log_dir = Path(log_dir_value)
+    else:
+        log_dir = DEFAULT_LOG_DIR
+
+    with setup_cli_logging(PROGRAM_NAME, log_cfg, date_str=None, log_dir=log_dir) as logging_ctx:
+        configure_logger(logging_ctx.log_cfg)
+        setattr(args, "_pipeline_config", pipeline_config)
+        setattr(args, "_csv_runtime_config", csv_cfg)
+        setattr(args, "_log_level", log_level)
+        exit_code = run(args)
+
+    return exit_code
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())
+

--- a/scripts/make_assay_postprocessing.py
+++ b/scripts/make_assay_postprocessing.py
@@ -1,0 +1,233 @@
+"""Command line interface for postprocessing assay exports."""
+
+from __future__ import annotations
+
+if __package__ in {None, ""}:
+    from _bootstrap import bootstrap_cli
+else:  # pragma: no cover - executed when imported as a package module
+    from ._bootstrap import bootstrap_cli
+
+bootstrap_cli(__package__, __file__)
+del bootstrap_cli
+
+import argparse
+import os
+from pathlib import Path
+from typing import Sequence
+
+import pandas as pd
+
+from library import io  # noqa: F401 - imported for CLI parity with existing scripts
+from library.cli import configure_logger, create_logger_config
+from library.cli.logging import setup_cli_logging
+from library.cli.parser import path_argument
+from library.common.log import logger
+from library.postprocess.assays.schema import ASSAY_SCHEMA, validate_assays
+from library.postprocess.assays.steps import run_assay_pipeline
+from library.postprocess.common.logging import PipelineRunMetrics
+from library.postprocess.common.types import SchemaValidationError, StepError
+
+from ._postprocess_common import (
+    CsvRuntimeConfig,
+    DEFAULT_LOG_DIR,
+    LOG_DIR_ENV,
+    export_postprocess_frame,
+    generate_metrics_report,
+    get_csv_runtime_config,
+    get_default_log_level,
+    get_pipeline_config,
+    load_input_frame,
+    run_postprocess_steps,
+    validate_postprocess_frame,
+)
+
+
+TABLE_NAME = "assays"
+PROGRAM_NAME = Path(__file__).with_suffix("").name
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create the command line parser for the assay postprocessor."""
+
+    parser = argparse.ArgumentParser(
+        description="Run the assay postprocessing pipeline on a CSV export.",
+    )
+    parser.add_argument(
+        "--input",
+        dest="input",
+        type=path_argument,
+        required=True,
+        help="Input CSV file containing raw assay records.",
+    )
+    parser.add_argument(
+        "--output",
+        dest="output",
+        type=path_argument,
+        required=True,
+        help="Destination CSV file for the postprocessed assays.",
+    )
+    parser.add_argument(
+        "--config",
+        dest="config",
+        type=path_argument,
+        default=None,
+        help="Optional YAML configuration overriding the default pipeline definition.",
+    )
+    parser.add_argument(
+        "--log-level",
+        dest="log_level",
+        default=None,
+        help="Logging verbosity (defaults to the pipeline configuration).",
+    )
+    return parser
+
+
+def load_output_data(path: Path, csv_cfg: CsvRuntimeConfig) -> pd.DataFrame:
+    """Load the raw assay output frame."""
+
+    return load_input_frame(TABLE_NAME, path, csv_cfg, logger=logger)
+
+
+def apply_postprocessing_steps(
+    df: pd.DataFrame,
+    *,
+    pipeline_version: str | None,
+) -> tuple[pd.DataFrame, PipelineRunMetrics]:
+    """Execute the configured assay postprocessing pipeline."""
+
+    return run_postprocess_steps(
+        TABLE_NAME,
+        df,
+        run_assay_pipeline,
+        pipeline_version,
+        logger=logger,
+    )
+
+
+def validate_output_schema(
+    df: pd.DataFrame,
+    *,
+    pipeline_version: str | None,
+) -> pd.DataFrame:
+    """Validate and reorder the DataFrame according to the assay schema."""
+
+    return validate_postprocess_frame(
+        TABLE_NAME,
+        df,
+        validate_assays,
+        ASSAY_SCHEMA,
+        pipeline_version,
+        logger=logger,
+    )
+
+
+def save_output_data(
+    df: pd.DataFrame,
+    output_path: Path,
+    csv_cfg: CsvRuntimeConfig,
+) -> Path:
+    """Persist ``df`` deterministically to ``output_path``."""
+
+    return export_postprocess_frame(
+        TABLE_NAME,
+        df,
+        output_path,
+        csv_cfg,
+        ASSAY_SCHEMA,
+        logger=logger,
+    )
+
+
+def run(args: argparse.Namespace) -> int:
+    """Execute the assay postprocessing pipeline using ``args``."""
+
+    pipeline_config = getattr(args, "_pipeline_config", None)
+    if pipeline_config is None:
+        pipeline_config = get_pipeline_config(TABLE_NAME, getattr(args, "config", None))
+    csv_cfg = getattr(args, "_csv_runtime_config", None)
+    if csv_cfg is None:
+        csv_cfg = get_csv_runtime_config(pipeline_config)
+
+    input_path = Path(args.input)
+    output_path = Path(args.output)
+    event_prefix = f"{TABLE_NAME}_postprocess"
+
+    if not input_path.exists():
+        logger.error(f"{event_prefix}_input_missing", input=str(input_path))
+        return 1
+
+    metrics: PipelineRunMetrics | None = None
+
+    try:
+        frame = load_output_data(input_path, csv_cfg)
+        processed, metrics = apply_postprocessing_steps(
+            frame,
+            pipeline_version=pipeline_config.pipeline_version,
+        )
+        validated = validate_output_schema(
+            processed,
+            pipeline_version=metrics.pipeline_version,
+        )
+        save_output_data(validated, output_path, csv_cfg)
+    except (SchemaValidationError, StepError) as exc:
+        logger.exception(f"{event_prefix}_failed", exc=exc)
+        return 1
+    except Exception as exc:  # pragma: no cover - defensive guard
+        logger.exception(f"{event_prefix}_unexpected_error", exc=exc)
+        return 1
+
+    if metrics is not None:
+        summary = metrics.summary()
+        summary["output"] = str(output_path)
+        logger.info(f"{event_prefix}_summary", **summary)
+
+    extras = {"input": str(input_path), "output": str(output_path)}
+    generate_metrics_report(
+        TABLE_NAME,
+        output_path,
+        csv_cfg,
+        run_assay_pipeline,
+        pipeline_version=metrics.pipeline_version if metrics else None,
+        extras=extras,
+        logger=logger,
+    )
+
+    logger.info(
+        f"{event_prefix}_done",
+        output=str(output_path),
+        rows=int(validated.shape[0]),
+        columns=int(validated.shape[1]),
+    )
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point wiring argument parsing and logging configuration."""
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    pipeline_config = get_pipeline_config(TABLE_NAME, getattr(args, "config", None))
+    csv_cfg = get_csv_runtime_config(pipeline_config)
+    log_level = (args.log_level or get_default_log_level(pipeline_config)).upper()
+    log_cfg = create_logger_config(log_level)
+
+    log_dir_value = os.environ.get(LOG_DIR_ENV)
+    if log_dir_value:
+        log_dir = Path(log_dir_value)
+    else:
+        log_dir = DEFAULT_LOG_DIR
+
+    with setup_cli_logging(PROGRAM_NAME, log_cfg, date_str=None, log_dir=log_dir) as logging_ctx:
+        configure_logger(logging_ctx.log_cfg)
+        setattr(args, "_pipeline_config", pipeline_config)
+        setattr(args, "_csv_runtime_config", csv_cfg)
+        setattr(args, "_log_level", log_level)
+        exit_code = run(args)
+
+    return exit_code
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())
+

--- a/scripts/make_document_postprocessing.py
+++ b/scripts/make_document_postprocessing.py
@@ -1,0 +1,233 @@
+"""Command line interface for postprocessing document exports."""
+
+from __future__ import annotations
+
+if __package__ in {None, ""}:
+    from _bootstrap import bootstrap_cli
+else:  # pragma: no cover - executed when imported as a package module
+    from ._bootstrap import bootstrap_cli
+
+bootstrap_cli(__package__, __file__)
+del bootstrap_cli
+
+import argparse
+import os
+from pathlib import Path
+from typing import Sequence
+
+import pandas as pd
+
+from library import io  # noqa: F401 - imported for CLI parity with existing scripts
+from library.cli import configure_logger, create_logger_config
+from library.cli.logging import setup_cli_logging
+from library.cli.parser import path_argument
+from library.common.log import logger
+from library.postprocess.common.logging import PipelineRunMetrics
+from library.postprocess.common.types import SchemaValidationError, StepError
+from library.postprocess.documents.schema import DOCUMENT_SCHEMA, validate_documents
+from library.postprocess.documents.steps import run_document_pipeline
+
+from ._postprocess_common import (
+    CsvRuntimeConfig,
+    DEFAULT_LOG_DIR,
+    LOG_DIR_ENV,
+    export_postprocess_frame,
+    generate_metrics_report,
+    get_csv_runtime_config,
+    get_default_log_level,
+    get_pipeline_config,
+    load_input_frame,
+    run_postprocess_steps,
+    validate_postprocess_frame,
+)
+
+
+TABLE_NAME = "documents"
+PROGRAM_NAME = Path(__file__).with_suffix("").name
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create the command line parser for the document postprocessor."""
+
+    parser = argparse.ArgumentParser(
+        description="Run the document postprocessing pipeline on a CSV export.",
+    )
+    parser.add_argument(
+        "--input",
+        dest="input",
+        type=path_argument,
+        required=True,
+        help="Input CSV file containing raw document records.",
+    )
+    parser.add_argument(
+        "--output",
+        dest="output",
+        type=path_argument,
+        required=True,
+        help="Destination CSV file for the postprocessed documents.",
+    )
+    parser.add_argument(
+        "--config",
+        dest="config",
+        type=path_argument,
+        default=None,
+        help="Optional YAML configuration overriding the default pipeline definition.",
+    )
+    parser.add_argument(
+        "--log-level",
+        dest="log_level",
+        default=None,
+        help="Logging verbosity (defaults to the pipeline configuration).",
+    )
+    return parser
+
+
+def load_output_data(path: Path, csv_cfg: CsvRuntimeConfig) -> pd.DataFrame:
+    """Load the raw document output frame."""
+
+    return load_input_frame(TABLE_NAME, path, csv_cfg, logger=logger)
+
+
+def apply_postprocessing_steps(
+    df: pd.DataFrame,
+    *,
+    pipeline_version: str | None,
+) -> tuple[pd.DataFrame, PipelineRunMetrics]:
+    """Execute the configured document postprocessing pipeline."""
+
+    return run_postprocess_steps(
+        TABLE_NAME,
+        df,
+        run_document_pipeline,
+        pipeline_version,
+        logger=logger,
+    )
+
+
+def validate_output_schema(
+    df: pd.DataFrame,
+    *,
+    pipeline_version: str | None,
+) -> pd.DataFrame:
+    """Validate and reorder the DataFrame according to the document schema."""
+
+    return validate_postprocess_frame(
+        TABLE_NAME,
+        df,
+        validate_documents,
+        DOCUMENT_SCHEMA,
+        pipeline_version,
+        logger=logger,
+    )
+
+
+def save_output_data(
+    df: pd.DataFrame,
+    output_path: Path,
+    csv_cfg: CsvRuntimeConfig,
+) -> Path:
+    """Persist ``df`` deterministically to ``output_path``."""
+
+    return export_postprocess_frame(
+        TABLE_NAME,
+        df,
+        output_path,
+        csv_cfg,
+        DOCUMENT_SCHEMA,
+        logger=logger,
+    )
+
+
+def run(args: argparse.Namespace) -> int:
+    """Execute the document postprocessing pipeline using ``args``."""
+
+    pipeline_config = getattr(args, "_pipeline_config", None)
+    if pipeline_config is None:
+        pipeline_config = get_pipeline_config(TABLE_NAME, getattr(args, "config", None))
+    csv_cfg = getattr(args, "_csv_runtime_config", None)
+    if csv_cfg is None:
+        csv_cfg = get_csv_runtime_config(pipeline_config)
+
+    input_path = Path(args.input)
+    output_path = Path(args.output)
+    event_prefix = f"{TABLE_NAME}_postprocess"
+
+    if not input_path.exists():
+        logger.error(f"{event_prefix}_input_missing", input=str(input_path))
+        return 1
+
+    metrics: PipelineRunMetrics | None = None
+
+    try:
+        frame = load_output_data(input_path, csv_cfg)
+        processed, metrics = apply_postprocessing_steps(
+            frame,
+            pipeline_version=pipeline_config.pipeline_version,
+        )
+        validated = validate_output_schema(
+            processed,
+            pipeline_version=metrics.pipeline_version,
+        )
+        save_output_data(validated, output_path, csv_cfg)
+    except (SchemaValidationError, StepError) as exc:
+        logger.exception(f"{event_prefix}_failed", exc=exc)
+        return 1
+    except Exception as exc:  # pragma: no cover - defensive guard
+        logger.exception(f"{event_prefix}_unexpected_error", exc=exc)
+        return 1
+
+    if metrics is not None:
+        summary = metrics.summary()
+        summary["output"] = str(output_path)
+        logger.info(f"{event_prefix}_summary", **summary)
+
+    extras = {"input": str(input_path), "output": str(output_path)}
+    generate_metrics_report(
+        TABLE_NAME,
+        output_path,
+        csv_cfg,
+        run_document_pipeline,
+        pipeline_version=metrics.pipeline_version if metrics else None,
+        extras=extras,
+        logger=logger,
+    )
+
+    logger.info(
+        f"{event_prefix}_done",
+        output=str(output_path),
+        rows=int(validated.shape[0]),
+        columns=int(validated.shape[1]),
+    )
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point wiring argument parsing and logging configuration."""
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    pipeline_config = get_pipeline_config(TABLE_NAME, getattr(args, "config", None))
+    csv_cfg = get_csv_runtime_config(pipeline_config)
+    log_level = (args.log_level or get_default_log_level(pipeline_config)).upper()
+    log_cfg = create_logger_config(log_level)
+
+    log_dir_value = os.environ.get(LOG_DIR_ENV)
+    if log_dir_value:
+        log_dir = Path(log_dir_value)
+    else:
+        log_dir = DEFAULT_LOG_DIR
+
+    with setup_cli_logging(PROGRAM_NAME, log_cfg, date_str=None, log_dir=log_dir) as logging_ctx:
+        configure_logger(logging_ctx.log_cfg)
+        setattr(args, "_pipeline_config", pipeline_config)
+        setattr(args, "_csv_runtime_config", csv_cfg)
+        setattr(args, "_log_level", log_level)
+        exit_code = run(args)
+
+    return exit_code
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())
+

--- a/scripts/make_target_postprocessing.py
+++ b/scripts/make_target_postprocessing.py
@@ -1,0 +1,233 @@
+"""Command line interface for postprocessing target exports."""
+
+from __future__ import annotations
+
+if __package__ in {None, ""}:
+    from _bootstrap import bootstrap_cli
+else:  # pragma: no cover - executed when imported as a package module
+    from ._bootstrap import bootstrap_cli
+
+bootstrap_cli(__package__, __file__)
+del bootstrap_cli
+
+import argparse
+import os
+from pathlib import Path
+from typing import Sequence
+
+import pandas as pd
+
+from library import io  # noqa: F401 - imported for CLI parity with existing scripts
+from library.cli import configure_logger, create_logger_config
+from library.cli.logging import setup_cli_logging
+from library.cli.parser import path_argument
+from library.common.log import logger
+from library.postprocess.common.logging import PipelineRunMetrics
+from library.postprocess.common.types import SchemaValidationError, StepError
+from library.postprocess.targets.schema import TARGET_SCHEMA, validate_targets
+from library.postprocess.targets.steps import run_target_pipeline
+
+from ._postprocess_common import (
+    CsvRuntimeConfig,
+    DEFAULT_LOG_DIR,
+    LOG_DIR_ENV,
+    export_postprocess_frame,
+    generate_metrics_report,
+    get_csv_runtime_config,
+    get_default_log_level,
+    get_pipeline_config,
+    load_input_frame,
+    run_postprocess_steps,
+    validate_postprocess_frame,
+)
+
+
+TABLE_NAME = "targets"
+PROGRAM_NAME = Path(__file__).with_suffix("").name
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create the command line parser for the target postprocessor."""
+
+    parser = argparse.ArgumentParser(
+        description="Run the target postprocessing pipeline on a CSV export.",
+    )
+    parser.add_argument(
+        "--input",
+        dest="input",
+        type=path_argument,
+        required=True,
+        help="Input CSV file containing raw target records.",
+    )
+    parser.add_argument(
+        "--output",
+        dest="output",
+        type=path_argument,
+        required=True,
+        help="Destination CSV file for the postprocessed targets.",
+    )
+    parser.add_argument(
+        "--config",
+        dest="config",
+        type=path_argument,
+        default=None,
+        help="Optional YAML configuration overriding the default pipeline definition.",
+    )
+    parser.add_argument(
+        "--log-level",
+        dest="log_level",
+        default=None,
+        help="Logging verbosity (defaults to the pipeline configuration).",
+    )
+    return parser
+
+
+def load_output_data(path: Path, csv_cfg: CsvRuntimeConfig) -> pd.DataFrame:
+    """Load the raw target output frame."""
+
+    return load_input_frame(TABLE_NAME, path, csv_cfg, logger=logger)
+
+
+def apply_postprocessing_steps(
+    df: pd.DataFrame,
+    *,
+    pipeline_version: str | None,
+) -> tuple[pd.DataFrame, PipelineRunMetrics]:
+    """Execute the configured target postprocessing pipeline."""
+
+    return run_postprocess_steps(
+        TABLE_NAME,
+        df,
+        run_target_pipeline,
+        pipeline_version,
+        logger=logger,
+    )
+
+
+def validate_output_schema(
+    df: pd.DataFrame,
+    *,
+    pipeline_version: str | None,
+) -> pd.DataFrame:
+    """Validate and reorder the DataFrame according to the target schema."""
+
+    return validate_postprocess_frame(
+        TABLE_NAME,
+        df,
+        validate_targets,
+        TARGET_SCHEMA,
+        pipeline_version,
+        logger=logger,
+    )
+
+
+def save_output_data(
+    df: pd.DataFrame,
+    output_path: Path,
+    csv_cfg: CsvRuntimeConfig,
+) -> Path:
+    """Persist ``df`` deterministically to ``output_path``."""
+
+    return export_postprocess_frame(
+        TABLE_NAME,
+        df,
+        output_path,
+        csv_cfg,
+        TARGET_SCHEMA,
+        logger=logger,
+    )
+
+
+def run(args: argparse.Namespace) -> int:
+    """Execute the target postprocessing pipeline using ``args``."""
+
+    pipeline_config = getattr(args, "_pipeline_config", None)
+    if pipeline_config is None:
+        pipeline_config = get_pipeline_config(TABLE_NAME, getattr(args, "config", None))
+    csv_cfg = getattr(args, "_csv_runtime_config", None)
+    if csv_cfg is None:
+        csv_cfg = get_csv_runtime_config(pipeline_config)
+
+    input_path = Path(args.input)
+    output_path = Path(args.output)
+    event_prefix = f"{TABLE_NAME}_postprocess"
+
+    if not input_path.exists():
+        logger.error(f"{event_prefix}_input_missing", input=str(input_path))
+        return 1
+
+    metrics: PipelineRunMetrics | None = None
+
+    try:
+        frame = load_output_data(input_path, csv_cfg)
+        processed, metrics = apply_postprocessing_steps(
+            frame,
+            pipeline_version=pipeline_config.pipeline_version,
+        )
+        validated = validate_output_schema(
+            processed,
+            pipeline_version=metrics.pipeline_version,
+        )
+        save_output_data(validated, output_path, csv_cfg)
+    except (SchemaValidationError, StepError) as exc:
+        logger.exception(f"{event_prefix}_failed", exc=exc)
+        return 1
+    except Exception as exc:  # pragma: no cover - defensive guard
+        logger.exception(f"{event_prefix}_unexpected_error", exc=exc)
+        return 1
+
+    if metrics is not None:
+        summary = metrics.summary()
+        summary["output"] = str(output_path)
+        logger.info(f"{event_prefix}_summary", **summary)
+
+    extras = {"input": str(input_path), "output": str(output_path)}
+    generate_metrics_report(
+        TABLE_NAME,
+        output_path,
+        csv_cfg,
+        run_target_pipeline,
+        pipeline_version=metrics.pipeline_version if metrics else None,
+        extras=extras,
+        logger=logger,
+    )
+
+    logger.info(
+        f"{event_prefix}_done",
+        output=str(output_path),
+        rows=int(validated.shape[0]),
+        columns=int(validated.shape[1]),
+    )
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point wiring argument parsing and logging configuration."""
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    pipeline_config = get_pipeline_config(TABLE_NAME, getattr(args, "config", None))
+    csv_cfg = get_csv_runtime_config(pipeline_config)
+    log_level = (args.log_level or get_default_log_level(pipeline_config)).upper()
+    log_cfg = create_logger_config(log_level)
+
+    log_dir_value = os.environ.get(LOG_DIR_ENV)
+    if log_dir_value:
+        log_dir = Path(log_dir_value)
+    else:
+        log_dir = DEFAULT_LOG_DIR
+
+    with setup_cli_logging(PROGRAM_NAME, log_cfg, date_str=None, log_dir=log_dir) as logging_ctx:
+        configure_logger(logging_ctx.log_cfg)
+        setattr(args, "_pipeline_config", pipeline_config)
+        setattr(args, "_csv_runtime_config", csv_cfg)
+        setattr(args, "_log_level", log_level)
+        exit_code = run(args)
+
+    return exit_code
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())
+

--- a/scripts/make_testitem_postprocessing.py
+++ b/scripts/make_testitem_postprocessing.py
@@ -1,0 +1,233 @@
+"""Command line interface for postprocessing test item exports."""
+
+from __future__ import annotations
+
+if __package__ in {None, ""}:
+    from _bootstrap import bootstrap_cli
+else:  # pragma: no cover - executed when imported as a package module
+    from ._bootstrap import bootstrap_cli
+
+bootstrap_cli(__package__, __file__)
+del bootstrap_cli
+
+import argparse
+import os
+from pathlib import Path
+from typing import Sequence
+
+import pandas as pd
+
+from library import io  # noqa: F401 - imported for CLI parity with existing scripts
+from library.cli import configure_logger, create_logger_config
+from library.cli.logging import setup_cli_logging
+from library.cli.parser import path_argument
+from library.common.log import logger
+from library.postprocess.common.logging import PipelineRunMetrics
+from library.postprocess.common.types import SchemaValidationError, StepError
+from library.postprocess.testitem.schema import TESTITEM_SCHEMA, validate_testitems
+from library.postprocess.testitem.steps import run_testitem_pipeline
+
+from ._postprocess_common import (
+    CsvRuntimeConfig,
+    DEFAULT_LOG_DIR,
+    LOG_DIR_ENV,
+    export_postprocess_frame,
+    generate_metrics_report,
+    get_csv_runtime_config,
+    get_default_log_level,
+    get_pipeline_config,
+    load_input_frame,
+    run_postprocess_steps,
+    validate_postprocess_frame,
+)
+
+
+TABLE_NAME = "testitems"
+PROGRAM_NAME = Path(__file__).with_suffix("").name
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create the command line parser for the test item postprocessor."""
+
+    parser = argparse.ArgumentParser(
+        description="Run the test item postprocessing pipeline on a CSV export.",
+    )
+    parser.add_argument(
+        "--input",
+        dest="input",
+        type=path_argument,
+        required=True,
+        help="Input CSV file containing raw test item records.",
+    )
+    parser.add_argument(
+        "--output",
+        dest="output",
+        type=path_argument,
+        required=True,
+        help="Destination CSV file for the postprocessed test items.",
+    )
+    parser.add_argument(
+        "--config",
+        dest="config",
+        type=path_argument,
+        default=None,
+        help="Optional YAML configuration overriding the default pipeline definition.",
+    )
+    parser.add_argument(
+        "--log-level",
+        dest="log_level",
+        default=None,
+        help="Logging verbosity (defaults to the pipeline configuration).",
+    )
+    return parser
+
+
+def load_output_data(path: Path, csv_cfg: CsvRuntimeConfig) -> pd.DataFrame:
+    """Load the raw test item output frame."""
+
+    return load_input_frame(TABLE_NAME, path, csv_cfg, logger=logger)
+
+
+def apply_postprocessing_steps(
+    df: pd.DataFrame,
+    *,
+    pipeline_version: str | None,
+) -> tuple[pd.DataFrame, PipelineRunMetrics]:
+    """Execute the configured test item postprocessing pipeline."""
+
+    return run_postprocess_steps(
+        TABLE_NAME,
+        df,
+        run_testitem_pipeline,
+        pipeline_version,
+        logger=logger,
+    )
+
+
+def validate_output_schema(
+    df: pd.DataFrame,
+    *,
+    pipeline_version: str | None,
+) -> pd.DataFrame:
+    """Validate and reorder the DataFrame according to the test item schema."""
+
+    return validate_postprocess_frame(
+        TABLE_NAME,
+        df,
+        validate_testitems,
+        TESTITEM_SCHEMA,
+        pipeline_version,
+        logger=logger,
+    )
+
+
+def save_output_data(
+    df: pd.DataFrame,
+    output_path: Path,
+    csv_cfg: CsvRuntimeConfig,
+) -> Path:
+    """Persist ``df`` deterministically to ``output_path``."""
+
+    return export_postprocess_frame(
+        TABLE_NAME,
+        df,
+        output_path,
+        csv_cfg,
+        TESTITEM_SCHEMA,
+        logger=logger,
+    )
+
+
+def run(args: argparse.Namespace) -> int:
+    """Execute the test item postprocessing pipeline using ``args``."""
+
+    pipeline_config = getattr(args, "_pipeline_config", None)
+    if pipeline_config is None:
+        pipeline_config = get_pipeline_config(TABLE_NAME, getattr(args, "config", None))
+    csv_cfg = getattr(args, "_csv_runtime_config", None)
+    if csv_cfg is None:
+        csv_cfg = get_csv_runtime_config(pipeline_config)
+
+    input_path = Path(args.input)
+    output_path = Path(args.output)
+    event_prefix = f"{TABLE_NAME}_postprocess"
+
+    if not input_path.exists():
+        logger.error(f"{event_prefix}_input_missing", input=str(input_path))
+        return 1
+
+    metrics: PipelineRunMetrics | None = None
+
+    try:
+        frame = load_output_data(input_path, csv_cfg)
+        processed, metrics = apply_postprocessing_steps(
+            frame,
+            pipeline_version=pipeline_config.pipeline_version,
+        )
+        validated = validate_output_schema(
+            processed,
+            pipeline_version=metrics.pipeline_version,
+        )
+        save_output_data(validated, output_path, csv_cfg)
+    except (SchemaValidationError, StepError) as exc:
+        logger.exception(f"{event_prefix}_failed", exc=exc)
+        return 1
+    except Exception as exc:  # pragma: no cover - defensive guard
+        logger.exception(f"{event_prefix}_unexpected_error", exc=exc)
+        return 1
+
+    if metrics is not None:
+        summary = metrics.summary()
+        summary["output"] = str(output_path)
+        logger.info(f"{event_prefix}_summary", **summary)
+
+    extras = {"input": str(input_path), "output": str(output_path)}
+    generate_metrics_report(
+        TABLE_NAME,
+        output_path,
+        csv_cfg,
+        run_testitem_pipeline,
+        pipeline_version=metrics.pipeline_version if metrics else None,
+        extras=extras,
+        logger=logger,
+    )
+
+    logger.info(
+        f"{event_prefix}_done",
+        output=str(output_path),
+        rows=int(validated.shape[0]),
+        columns=int(validated.shape[1]),
+    )
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point wiring argument parsing and logging configuration."""
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    pipeline_config = get_pipeline_config(TABLE_NAME, getattr(args, "config", None))
+    csv_cfg = get_csv_runtime_config(pipeline_config)
+    log_level = (args.log_level or get_default_log_level(pipeline_config)).upper()
+    log_cfg = create_logger_config(log_level)
+
+    log_dir_value = os.environ.get(LOG_DIR_ENV)
+    if log_dir_value:
+        log_dir = Path(log_dir_value)
+    else:
+        log_dir = DEFAULT_LOG_DIR
+
+    with setup_cli_logging(PROGRAM_NAME, log_cfg, date_str=None, log_dir=log_dir) as logging_ctx:
+        configure_logger(logging_ctx.log_cfg)
+        setattr(args, "_pipeline_config", pipeline_config)
+        setattr(args, "_csv_runtime_config", csv_cfg)
+        setattr(args, "_log_level", log_level)
+        exit_code = run(args)
+
+    return exit_code
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())
+

--- a/tests/integration/test_make_activity_postprocessing.py
+++ b/tests/integration/test_make_activity_postprocessing.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+
+import pandas as pd
+
+from library.postprocess.activities.schema import ACTIVITY_SCHEMA
+
+from scripts import make_activity_postprocessing as cli
+
+
+def test_make_activity_postprocessing__end_to_end(tmp_path, monkeypatch):
+    log_dir = tmp_path / "logs"
+    monkeypatch.setenv("CHEMBL_POSTPROCESS_LOG_DIR", str(log_dir))
+
+    input_path = tmp_path / "activities_raw.csv"
+    df = pd.DataFrame(
+        {
+            "activity_id": [2, 1],
+            "molecule_chembl_id": ["CHEMBL2", "CHEMBL1"],
+            "assay_chembl_id": ["ASSAY2", "ASSAY1"],
+            "standard_type": ["IC50", "Ki"],
+            "standard_relation": ["=", "<"],
+            "standard_value": [10.0, 5.0],
+            "standard_units": ["nM", "nM"],
+            "data_validity_comment": ["Valid result", None],
+        }
+    )
+    df.to_csv(input_path, index=False)
+
+    output_path = tmp_path / "activities_processed.csv"
+    exit_code = cli.main(["--input", str(input_path), "--output", str(output_path)])
+    assert exit_code == 0
+
+    result = pd.read_csv(output_path)
+    expected_columns = [col for col in ACTIVITY_SCHEMA.column_order if col in result.columns]
+    assert list(result.columns) == expected_columns
+    assert result["molecule_chembl_id"].tolist() == ["CHEMBL1", "CHEMBL2"]
+    assert result["standard_units"].tolist() == ["NM", "NM"]
+    assert result["quality_flag"].tolist() == [False, True]
+    assert result["pipeline_version"].notna().all()
+
+    # Ensure deterministic ordering and schema compliance
+    expected_sort = result.sort_values(
+        ["molecule_chembl_id", "assay_chembl_id", "activity_id"],
+        kind="mergesort",
+    ).reset_index(drop=True)
+    pd.testing.assert_frame_equal(result, expected_sort)
+
+    # Metrics report is generated next to the output
+    report_path = output_path.parent / "activities.postprocess.report.json"
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+    assert payload["table"] == "activities"
+    assert payload["output_path"] == str(output_path)
+    assert payload["metrics"]["output"]["rows"] == len(result)
+
+    # Log file is created with the expected naming convention
+    date_str = datetime.now(timezone.utc).strftime("%Y%m%d")
+    log_path = log_dir / f"make_activity_postprocessing_{date_str}.log"
+    assert log_path.exists()
+
+    # Idempotent reruns keep the output stable
+    initial_digest = output_path.read_bytes()
+    second_exit = cli.main(["--input", str(input_path), "--output", str(output_path)])
+    assert second_exit == 0
+    assert output_path.read_bytes() == initial_digest
+

--- a/tests/integration/test_make_assay_postprocessing.py
+++ b/tests/integration/test_make_assay_postprocessing.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+
+import pandas as pd
+
+from library.postprocess.assays.schema import ASSAY_SCHEMA
+
+from scripts import make_assay_postprocessing as cli
+
+
+def test_make_assay_postprocessing__end_to_end(tmp_path, monkeypatch):
+    log_dir = tmp_path / "logs"
+    monkeypatch.setenv("CHEMBL_POSTPROCESS_LOG_DIR", str(log_dir))
+
+    input_path = tmp_path / "assays_raw.csv"
+    df = pd.DataFrame(
+        {
+            "assay_chembl_id": ["CHEMBL3", " chembl2"],
+            "assay_type": [" primary", "confirmatory"],
+            "assay_test_type": ["functional", "BINDING"],
+            "description": [" first entry ", "second"],
+            "target_chembl_id": [" t1", "t2"],
+        }
+    )
+    df.to_csv(input_path, index=False)
+
+    output_path = tmp_path / "assays_processed.csv"
+    exit_code = cli.main(["--input", str(input_path), "--output", str(output_path)])
+    assert exit_code == 0
+
+    result = pd.read_csv(output_path)
+    expected_columns = [col for col in ASSAY_SCHEMA.column_order if col in result.columns]
+    assert list(result.columns) == expected_columns
+    assert result["assay_chembl_id"].tolist() == ["CHEMBL2", "CHEMBL3"]
+    assert result["assay_type"].tolist() == ["CONFIRMATORY", "PRIMARY"]
+    assert result["assay_test_type"].tolist() == ["BINDING", "FUNCTIONAL"]
+    assert result["description"].tolist() == ["second", " first entry "]
+    assert result["target_chembl_id"].tolist() == ["T2", "T1"]
+    assert result["is_confirmatory"].tolist() == [True, True]
+    assert result["pipeline_version"].notna().all()
+
+    report_path = output_path.parent / "assays.postprocess.report.json"
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+    assert payload["table"] == "assays"
+    assert payload["metrics"]["output"]["rows"] == len(result)
+
+    date_str = datetime.now(timezone.utc).strftime("%Y%m%d")
+    log_path = log_dir / f"make_assay_postprocessing_{date_str}.log"
+    assert log_path.exists()
+
+    snapshot = output_path.read_bytes()
+    second_exit = cli.main(["--input", str(input_path), "--output", str(output_path)])
+    assert second_exit == 0
+    assert output_path.read_bytes() == snapshot
+

--- a/tests/integration/test_make_document_postprocessing.py
+++ b/tests/integration/test_make_document_postprocessing.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+
+import pandas as pd
+
+from library.postprocess.documents.schema import DOCUMENT_SCHEMA
+
+from scripts import make_document_postprocessing as cli
+
+
+def test_make_document_postprocessing__end_to_end(tmp_path, monkeypatch):
+    log_dir = tmp_path / "logs"
+    monkeypatch.setenv("CHEMBL_POSTPROCESS_LOG_DIR", str(log_dir))
+
+    input_path = tmp_path / "documents_raw.csv"
+    df = pd.DataFrame(
+        {
+            "document_chembl_id": ["CHEMBL_DOC2", "CHEMBL_DOC1"],
+            "title": ["  First Document  ", "Second"],
+            "doc_type": ["article", "journal"],
+            "year": [2020, 2019],
+            "journal": ["  Nature ", "Science"],
+        }
+    )
+    df.to_csv(input_path, index=False)
+
+    output_path = tmp_path / "documents_processed.csv"
+    exit_code = cli.main(["--input", str(input_path), "--output", str(output_path)])
+    assert exit_code == 0
+
+    result = pd.read_csv(output_path)
+    expected_columns = [col for col in DOCUMENT_SCHEMA.column_order if col in result.columns]
+    assert list(result.columns) == expected_columns
+    assert result["document_chembl_id"].tolist() == ["CHEMBL_DOC1", "CHEMBL_DOC2"]
+    assert result["title"].tolist() == ["Second", "First Document"]
+    assert result["doc_type"].tolist() == ["journal", "article"]
+    assert result["publication_year"].tolist() == [2019, 2020]
+    assert result["year"].tolist() == [2019, 2020]
+    assert result["journal"].tolist() == ["Science", "Nature"]
+    assert result["pipeline_version"].notna().all()
+
+    report_path = output_path.parent / "documents.postprocess.report.json"
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+    assert payload["table"] == "documents"
+    assert payload["metrics"]["output"]["rows"] == len(result)
+
+    date_str = datetime.now(timezone.utc).strftime("%Y%m%d")
+    log_path = log_dir / f"make_document_postprocessing_{date_str}.log"
+    assert log_path.exists()
+
+    snapshot = output_path.read_bytes()
+    second_exit = cli.main(["--input", str(input_path), "--output", str(output_path)])
+    assert second_exit == 0
+    assert output_path.read_bytes() == snapshot
+

--- a/tests/integration/test_make_target_postprocessing.py
+++ b/tests/integration/test_make_target_postprocessing.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+
+import pandas as pd
+
+from library.postprocess.targets.schema import TARGET_SCHEMA
+
+from scripts import make_target_postprocessing as cli
+
+
+def test_make_target_postprocessing__end_to_end(tmp_path, monkeypatch):
+    log_dir = tmp_path / "logs"
+    monkeypatch.setenv("CHEMBL_POSTPROCESS_LOG_DIR", str(log_dir))
+
+    input_path = tmp_path / "targets_raw.csv"
+    df = pd.DataFrame(
+        {
+            "target_chembl_id": ["t2", " t1"],
+            "pref_name": [" Kinase ", "Receptor"],
+            "target_type": ["protein", "PROTEIN FAMILY"],
+            "synonyms": ["alpha;beta", None],
+            "chembl_synonyms": [None, "gamma"],
+            "gtopdb_synonyms": ["delta", None],
+        }
+    )
+    df.to_csv(input_path, index=False)
+
+    output_path = tmp_path / "targets_processed.csv"
+    exit_code = cli.main(["--input", str(input_path), "--output", str(output_path)])
+    assert exit_code == 0
+
+    result = pd.read_csv(output_path)
+    expected_columns = [col for col in TARGET_SCHEMA.column_order if col in result.columns]
+    assert list(result.columns)[: len(expected_columns)] == expected_columns
+    assert {"chembl_synonyms", "gtopdb_synonyms"}.issubset(result.columns)
+    assert result["target_chembl_id"].tolist() == ["T1", "T2"]
+    assert result["pref_name"].tolist() == ["Receptor", "Kinase"]
+    assert result["synonyms"].tolist() == ["gamma", "alpha; beta; delta"]
+    chembl_synonyms = result["chembl_synonyms"].tolist()
+    gtopdb_synonyms = result["gtopdb_synonyms"].tolist()
+    assert chembl_synonyms[0] == "gamma"
+    assert pd.isna(chembl_synonyms[1])
+    assert pd.isna(gtopdb_synonyms[0])
+    assert gtopdb_synonyms[1] == "delta"
+    assert result["organism"].isna().all()
+    assert result["target_class"].isna().all()
+    assert result["protein_family"].isna().all()
+    assert result["pipeline_version"].notna().all()
+
+    report_path = output_path.parent / "targets.postprocess.report.json"
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+    assert payload["table"] == "targets"
+    assert payload["metrics"]["output"]["rows"] == len(result)
+
+    date_str = datetime.now(timezone.utc).strftime("%Y%m%d")
+    log_path = log_dir / f"make_target_postprocessing_{date_str}.log"
+    assert log_path.exists()
+
+    snapshot = output_path.read_bytes()
+    second_exit = cli.main(["--input", str(input_path), "--output", str(output_path)])
+    assert second_exit == 0
+    assert output_path.read_bytes() == snapshot
+

--- a/tests/integration/test_make_testitem_postprocessing.py
+++ b/tests/integration/test_make_testitem_postprocessing.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+
+import pandas as pd
+
+from library.postprocess.testitem.schema import TESTITEM_SCHEMA
+
+from scripts import make_testitem_postprocessing as cli
+
+
+def test_make_testitem_postprocessing__end_to_end(tmp_path, monkeypatch):
+    log_dir = tmp_path / "logs"
+    monkeypatch.setenv("CHEMBL_POSTPROCESS_LOG_DIR", str(log_dir))
+
+    input_path = tmp_path / "testitems_raw.csv"
+    df = pd.DataFrame(
+        {
+            "molecule_chembl_id": ["chembl2", " CHEMBL1"],
+            "parent_molecule_chembl_id": [" chembl3", None],
+            "pref_name": [" Test Item ", "Compound"],
+            "natural_product": ["YES", ""],
+            "prodrug": [0, 1],
+            "polymer_flag": [None, "true"],
+            "pubchem_cid": ["123", ""],
+            "timestamp_utc": ["2021-01-01T00:00:00Z", None],
+        }
+    )
+    df.to_csv(input_path, index=False)
+
+    output_path = tmp_path / "testitems_processed.csv"
+    exit_code = cli.main(["--input", str(input_path), "--output", str(output_path)])
+    assert exit_code == 0
+
+    result = pd.read_csv(output_path)
+    assert list(result.columns) == list(TESTITEM_SCHEMA.column_order)
+    assert result["molecule_chembl_id"].tolist() == ["CHEMBL1", "CHEMBL2"]
+    parents = result["parent_molecule_chembl_id"].tolist()
+    assert pd.isna(parents[0])
+    assert parents[1] == "CHEMBL3"
+    assert result["pref_name"].tolist() == ["Compound", "Test Item"]
+    natural = result["natural_product"].astype("boolean")
+    polymer = result["polymer_flag"].astype("boolean")
+    assert pd.isna(natural.iloc[0])
+    assert bool(natural.iloc[1]) is True
+    assert bool(polymer.iloc[0]) is True
+    assert pd.isna(polymer.iloc[1])
+    assert result["prodrug"].astype("boolean").tolist() == [True, False]
+    assert result["pipeline_version"].notna().all()
+
+    report_path = output_path.parent / "testitems.postprocess.report.json"
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+    assert payload["table"] == "testitems"
+    assert payload["metrics"]["output"]["rows"] == len(result)
+
+    date_str = datetime.now(timezone.utc).strftime("%Y%m%d")
+    log_path = log_dir / f"make_testitem_postprocessing_{date_str}.log"
+    assert log_path.exists()
+
+    snapshot = output_path.read_bytes()
+    second_exit = cli.main(["--input", str(input_path), "--output", str(output_path)])
+    assert second_exit == 0
+    assert output_path.read_bytes() == snapshot
+


### PR DESCRIPTION
## Summary
- add shared helpers for postprocessing CLIs and wire up activity, assay, document, target, and test item entrypoints
- introduce the test item postprocessing pipeline configuration, schema, and steps
- document the new commands and cover them with integration tests

## Testing
- pytest tests/integration/test_make_activity_postprocessing.py tests/integration/test_make_assay_postprocessing.py tests/integration/test_make_document_postprocessing.py tests/integration/test_make_target_postprocessing.py tests/integration/test_make_testitem_postprocessing.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e683e664d88324bb5709e082ee871c