### PR TITLE
Handle non-numeric ranges in document export loader

### DIFF
--- a/library/postprocessing/document.py
+++ b/library/postprocessing/document.py
@@ -925,6 +925,15 @@ OUTPUT_DTYPE = {
     "ChEMBL.source": "string",
 }
 
+OUTPUT_INT64_COLUMNS: tuple[str, ...] = tuple(
+    column for column, dtype in OUTPUT_DTYPE.items() if dtype == "Int64"
+)
+
+OUTPUT_READ_DTYPE = {
+    column: ("string" if column in OUTPUT_INT64_COLUMNS else dtype)
+    for column, dtype in OUTPUT_DTYPE.items()
+}
+
 
 def _load_reference_document(path: Path) -> pd.DataFrame:
     if not path.exists():
@@ -969,13 +978,21 @@ def _load_reference_document(path: Path) -> pd.DataFrame:
 
 
 def _load_output_document(path: Path) -> pd.DataFrame:
-    return pd.read_csv(
+    frame = pd.read_csv(
         path,
-        dtype=OUTPUT_DTYPE,
+        dtype=OUTPUT_READ_DTYPE,
         encoding=UTF8_ENCODING,
         sep=CSV_DELIMITER,
         keep_default_na=True,
     )
+
+    for column in OUTPUT_INT64_COLUMNS:
+        if column not in frame.columns:
+            continue
+        numeric = pd.to_numeric(frame[column], errors="coerce")
+        frame[column] = numeric.astype("Int64")
+
+    return frame
 
 
 # ---------------------------------------------------------------------------

--- a/tests/postprocessing/test_document_postprocessing.py
+++ b/tests/postprocessing/test_document_postprocessing.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from library.postprocessing import document
+
+
+@pytest.mark.unit
+def test_load_output_document__coerces_invalid_numeric_ranges(tmp_path):
+    columns = list(document.OUTPUT_DTYPE.keys())
+    row = {column: "" for column in columns}
+
+    row.update(
+        {
+            "ChEMBL.document_chembl_id": "DOC0001",
+            "ChEMBL.issue": "11-12",
+            "ChEMBL.year": "2020",
+            "PubMed.PMID": "12345",
+        }
+    )
+
+    frame = pd.DataFrame([row], columns=columns)
+    csv_path = tmp_path / "output.csv"
+    frame.to_csv(csv_path, index=False)
+
+    loaded = document._load_output_document(csv_path)
+
+    assert loaded["ChEMBL.issue"].dtype == "Int64"
+    assert pd.isna(loaded.at[0, "ChEMBL.issue"])
+    assert loaded["ChEMBL.year"].dtype == "Int64"
+    assert loaded.at[0, "ChEMBL.year"] == 2020
+    assert loaded["PubMed.PMID"].dtype == "Int64"
+    assert loaded.at[0, "PubMed.PMID"] == 12345


### PR DESCRIPTION
## Summary
- coerce ranged numeric fields to nullable integers when loading the document export to avoid read_csv conversion failures
- add a regression test covering ranged numeric values in document exports

## Testing
- pytest tests/postprocessing/test_document_postprocessing.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e68bb621f48324bb149eadbd3517eb